### PR TITLE
fix: separate app-name resolution for container creation

### DIFF
--- a/fkh-backend/Services/FkhCreateContainer.cs
+++ b/fkh-backend/Services/FkhCreateContainer.cs
@@ -55,7 +55,7 @@ public class FkhCreateContainer : FkhServiceBase
 
         var imageTag = GetImageTag(artifactUrl);
         var fullImage = $"{AcrLoginServer}/{AcrRepository}:{imageTag}";
-        var appName = ResolveAppName(parameters);
+        var appName = ResolveNewAppName(parameters);
         var databaseName = appName;
 
         if (!Regex.IsMatch(databaseName, @"^[a-zA-Z0-9_-]+$"))

--- a/fkh-backend/Services/FkhServiceBase.cs
+++ b/fkh-backend/Services/FkhServiceBase.cs
@@ -344,6 +344,27 @@ public abstract class FkhServiceBase
         return SanitizeAppName($"{githubUsername}-{name}");
     }
 
+    /// <summary>
+    /// Resolves the app label for a NEW container being created.
+    /// Unlike <see cref="ResolveAppName"/>, this never interprets a hyphen in the
+    /// supplied name as a reference to someone else's container — a hyphen is just
+    /// a valid character in a container name (e.g. "my-app"). The caller's own
+    /// "username-" prefix is always applied unless the supplied name already starts
+    /// with it. This guarantees every newly created container is owned by its creator
+    /// and will be found by ownership-prefix filters (listing, quotas, etc.).
+    /// </summary>
+    protected static string ResolveNewAppName(Dictionary<string, string> parameters)
+    {
+        var name = parameters["name"];
+        var githubUsername = parameters["_githubUsername"];
+
+        var ownPrefix = $"{githubUsername}-";
+
+        return name.StartsWith(ownPrefix, StringComparison.OrdinalIgnoreCase)
+            ? SanitizeAppName(name)
+            : SanitizeAppName($"{githubUsername}-{name}");
+    }
+
 
 
     protected const string SqlcmdPath = "/opt/mssql-tools18/bin/sqlcmd";


### PR DESCRIPTION
## Summary

Fixes #27.

Container creation reused `ResolveAppName`, which applies a heuristic intended for *looking up* an existing container: a hyphen in the supplied name is treated as a sign that the name belongs to another user (`{otherUsername}-{containerName}`), so admins get it used as-is, and non-admins are rejected outright.

That heuristic doesn't apply during creation — there is no existing container to "reference," only a new name the user is choosing. As a result, creating a container whose name itself contained a hyphen (e.g. `my-app`) either threw an `UnauthorizedAccessException` for non-admins, or silently skipped the creator's username prefix for admins. Containers created this way weren't recognized as belonging to their creator: they didn't show up in the default container listing (including in the VS Code extension), weren't counted toward the creator's `MaxContainers` quota, and had their owner mis-parsed wherever the `app` label is split on the last hyphen.

## Change

Adds `ResolveNewAppName` in `FkhServiceBase`, used only by `FkhCreateContainer`. It always applies the creator's own `{githubUsername}-` prefix unless the supplied name already starts with it, and never interprets an embedded hyphen as a reference to someone else's container.

`ResolveAppName` itself is unchanged and continues to be used by all operations that reference an *existing* container (`FkhRemoveContainer`, `FkhScaleContainer`, `FkhGetContainerDetails`, etc.), preserving the intended admin cross-user lookup behavior described in its docstring.

## Files changed
- `fkh-backend/Services/FkhServiceBase.cs`
- `fkh-backend/Services/FkhCreateContainer.cs`

## Notes
This does not retroactively fix containers already created without the correct prefix before this fix — those would need a manual label/migration step if they should be re-associated with their creator.