### PR TITLE
fix: Add BC standard audience for VS Code AAD auth (#29)

### DIFF
--- a/ContainerScripts/SetupConfiguration.ps1
+++ b/ContainerScripts/SetupConfiguration.ps1
@@ -4,7 +4,7 @@ if ($auth -eq "AccessControlService") {
     $CustomConfigFile =  Join-Path $ServiceTierFolder "CustomSettings.config"
     $CustomConfig = [xml](Get-Content $CustomConfigFile)
     if ($null -ne $customConfig.SelectSingleNode("//appSettings/add[@key='ValidAudiences']")) {
-        $validAudiences = "$($env:aadAppId);$($env:appIdUri);$validAudiences"
+        $validAudiences = "$($env:aadAppId);$($env:appIdUri);https://api.businesscentral.dynamics.com;$validAudiences"
         Write-Host "Setting ValidAudiences to $validAudiences in $CustomConfigFile"
         $CustomConfig.SelectSingleNode("//appSettings/add[@key='ValidAudiences']").value = $validAudiences
         $CustomConfig.Save($CustomConfigFile)


### PR DESCRIPTION
Fixes #29

**Description**
As discussed in the issue, this PR adds the standard Microsoft Cloud URL (`https://api.businesscentral.dynamics.com`) to the `$validAudiences` string in `SetupConfiguration.ps1`.

Without this URL, VS Code (AL Extension) fails to connect when using `"authentication": "AAD"`, rejecting the connection with a `SecurityTokenInvalidAudienceException`.

**Changes**
- Appended `https://api.businesscentral.dynamics.com` to the `$validAudiences` concatenation.