### PR TITLE
Add Autorefresh to the fkh Web App

### DIFF
--- a/fkh-web/src/App.tsx
+++ b/fkh-web/src/App.tsx
@@ -136,6 +136,10 @@ export function App() {
     }
   }, [token, backendUrl, showAll]);
 
+  const handleRefreshContainers = useCallback(() => {
+    fetchContainers();
+  }, [fetchContainers]);
+
   // Load containers once authenticated
   useEffect(() => {
     if (token && backendUrl) {
@@ -283,7 +287,7 @@ export function App() {
           showAll={showAll}
           canShowAll={isAdmin}
           onToggleAll={handleToggleAll}
-          onRefresh={() => fetchContainers()}
+          onRefresh={handleRefreshContainers}
           onStart={handleStart}
           onStop={handleStop}
           actionInProgress={actionInProgress}

--- a/fkh-web/src/components/ContainerList.tsx
+++ b/fkh-web/src/components/ContainerList.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ContainerInfo } from '../types';
 import { DropdownMenu } from './DropdownMenu';
 import type { MenuEntry } from './DropdownMenu';
+
+const AUTO_REFRESH_INTERVAL_MS = 60_000;
 
 interface ContainerListProps {
   containers: ContainerInfo[];
@@ -28,6 +30,28 @@ export function ContainerList({
   onStop,
   actionInProgress,
 }: ContainerListProps) {
+  const loadingRef = useRef(loading);
+  const [refreshTimerReset, setRefreshTimerReset] = useState(0);
+
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  const refreshAndResetTimer = useCallback(() => {
+    setRefreshTimerReset(value => value + 1);
+    onRefresh();
+  }, [onRefresh]);
+
+  useEffect(() => {
+    const refreshTimer = window.setInterval(() => {
+      if (!loadingRef.current) {
+        refreshAndResetTimer();
+      }
+    }, AUTO_REFRESH_INTERVAL_MS);
+
+    return () => window.clearInterval(refreshTimer);
+  }, [refreshAndResetTimer, refreshTimerReset]);
+
   return (
     <div className="container-list">
       <div className="list-toolbar">
@@ -37,7 +61,7 @@ export function ContainerList({
             <input type="checkbox" checked={showAll} onChange={onToggleAll} disabled={!canShowAll} />
             Show all
           </label>
-          <button className="btn btn-sm btn-secondary" onClick={onRefresh} disabled={loading}>
+          <button className="btn btn-sm btn-secondary" onClick={refreshAndResetTimer} disabled={loading}>
             {loading ? 'Loading...' : 'Refresh'}
           </button>
         </div>


### PR DESCRIPTION
This pull request introduces an automatic refresh feature to the container list and refactors refresh handling for improved code clarity and user experience. Now, the container list will automatically refresh every 60 seconds when not loading, and manual refreshes will reset the timer. The refresh logic is also centralized for consistency.

**Automatic Refresh Functionality:**
* Added an interval in `ContainerList` to automatically refresh the container list every 60 seconds, provided a refresh is not already in progress. Manual refreshes reset this timer. [[1]](diffhunk://#diff-989977cdd29504dc1ceac5a21b2f340ba20ec66cc20f7225b5e30da8829c11a8L1-R7) [[2]](diffhunk://#diff-989977cdd29504dc1ceac5a21b2f340ba20ec66cc20f7225b5e30da8829c11a8R33-R54)

**Refresh Logic Refactoring:**
* Introduced a new `handleRefreshContainers` callback in `App` to encapsulate refresh logic and passed it to `ContainerList` for both manual and automatic refreshes. [[1]](diffhunk://#diff-8003e635bfb2bff4ab75a8ec967153887c7bac5dfecd000262557e38712cd1c2R139-R142) [[2]](diffhunk://#diff-8003e635bfb2bff4ab75a8ec967153887c7bac5dfecd000262557e38712cd1c2L286-R290)
* Updated the refresh button in `ContainerList` to use the new `refreshAndResetTimer` function, ensuring a consistent refresh experience and timer reset on manual refresh.