### PR TITLE
Add uploadFile and downloadfile commands to CLI

### DIFF
--- a/.github/api-v1-contract.md
+++ b/.github/api-v1-contract.md
@@ -220,6 +220,8 @@ These are not returned by the catalog but can be invoked directly by clients tha
 |---|---|---|---|
 | GetDatabaseUploadSas | `POST /GetDatabaseUploadSas` | **Yes** | Returns a SAS URL for uploading database backups |
 | GetDatabaseDownloadSas | `POST /GetDatabaseDownloadSas` | No | Returns a read-only SAS URL for downloading database backups |
+| GetFileUploadSas | `POST /GetFileUploadSas` | **Yes** | Returns a SAS URL for uploading versioned files |
+| GetFileDownloadSas | `POST /GetFileDownloadSas` | No | Returns a read-only SAS URL for downloading versioned files |
 | Status | `POST /Status` | **Yes** | Returns full system status (nodes, containers, SQL, storage, quotas, security) |
 
 ---
@@ -435,6 +437,14 @@ No parameters.
 | `containerName` | string | no | `databases` | Blob container name |
 
 ### GetDatabaseDownloadSas (hidden)
+
+No parameters.
+
+### GetFileUploadSas (hidden)
+
+No parameters.
+
+### GetFileDownloadSas (hidden)
 
 No parameters.
 

--- a/Installation/Step1-DeploymentRepo.md
+++ b/Installation/Step1-DeploymentRepo.md
@@ -67,7 +67,7 @@ You can create the private deployment repository with the Fkh CLI or manually in
 Run the following command:
 
 ```pwsh
-fkh createdeploymentrepo --deploymentRepo org/repo [--fkhRepo fkhForkOrg/fkhForkRepo]
+fkh createdeploymentrepo --deploymentRepo org/repo [--fkhRepo fkhForkOrg/fkhForkRepo[@version]]
 ```
 
 Replace `org/repo` with the GitHub organization and repository name for the private deployment repository.
@@ -77,9 +77,10 @@ Examples:
 ```pwsh
 fkh createdeploymentrepo --deploymentRepo my-company/fkh-deploy-contoso
 fkh createdeploymentrepo --deploymentRepo my-company/fkh-deploy-contoso --fkhRepo my-company/Fkh
+fkh createdeploymentrepo --deploymentRepo my-company/fkh-deploy-contoso --fkhRepo my-company/Fkh@dev
 ```
 
-Use `--fkhRepo` only when you created your own Fkh fork. If you omit it, the CLI uses the default Fkh source repository.
+Use `--fkhRepo` only when you created your own Fkh fork or want to pin a specific Fkh version. The optional `@version` suffix can be a tag, branch, `latest`, or `preview`; when omitted, the CLI uses `latest` from the selected source repository.
 
 ### Option B — Create the repository manually in GitHub
 

--- a/deployment-repo/README.md
+++ b/deployment-repo/README.md
@@ -72,13 +72,14 @@ fkh updatedeploymentrepo --deploymentRepo my-company/fkh-deploy-contoso --fkhRep
 fkh updatedeploymentrepo --deploymentRepo my-company/fkh-deploy-contoso --fkhRepo my-company/Fkh@dev
 ```
 
-The optional `@branch` suffix controls which branch of the Fkh fork is used for fetching templates and for the reusable workflow references in the caller workflows. When omitted it defaults to `main`. This is useful for testing Fkh changes on a feature branch without affecting other deployments.
+The optional `@version` suffix controls which tag, branch, or alias (`latest` or `preview`) of the Fkh fork is used for fetching templates and for the reusable workflow references in the caller workflows. When omitted it defaults to `latest`. This is useful for testing Fkh changes on a feature branch without affecting other deployments.
 
 What it does:
 
 - Clones the deployment repository to a temporary folder.
 - Fetches every file from the `deployment-repo/` folder of the Fkh repository (or fork) at the specified branch and writes it into the deployment repo, creating any missing folders.
 - In `.yml` files, rewrites the default `Freddy-DK/Fkh` reference and `@main` branch reference to your `--fkhRepo` value when one is provided.
+- Updates the **Update Fkh Version** workflow defaults to the same Fkh fork and version you provided, so the next workflow run starts with the last selected source.
 - **Never overwrites `config/deployment.tfvars`** — your environment-specific configuration is preserved.
 - Commits and pushes the changes using your `gh` user identity.
 

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -595,6 +595,23 @@ public static class FunctionCatalog
         },
         new FunctionDefinition
         {
+            Name = "GetFileUploadSas",
+            Description = "Returns a SAS URL for uploading versioned files to blob storage. Admin only.",
+            Route = "GetFileUploadSas",
+            Hidden = true,
+            AdminOnly = true,
+            Parameters = new List<FunctionParameterDefinition>()
+        },
+        new FunctionDefinition
+        {
+            Name = "GetFileDownloadSas",
+            Description = "Returns a read-only SAS URL for downloading versioned files from blob storage.",
+            Route = "GetFileDownloadSas",
+            Hidden = true,
+            Parameters = new List<FunctionParameterDefinition>()
+        },
+        new FunctionDefinition
+        {
             Name = "ListPrepulled",
             Description = "Lists images currently configured for pre-pulling on Windows nodes. Admin only.",
             Route = "ListPrepulled",

--- a/fkh-backend/GetFileDownloadSasFunction.cs
+++ b/fkh-backend/GetFileDownloadSasFunction.cs
@@ -1,0 +1,28 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class GetFileDownloadSasFunction : FunctionBase
+{
+    private readonly ILogger<GetFileDownloadSasFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhGetFileDownloadSas _getFileDownloadSas;
+
+    public GetFileDownloadSasFunction(
+        ILogger<GetFileDownloadSasFunction> logger,
+        GitHubAuthService gitHub,
+        FkhGetFileDownloadSas getFileDownloadSas)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _getFileDownloadSas = getFileDownloadSas;
+    }
+
+    [Function("GetFileDownloadSas")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "GetFileDownloadSas")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "GetFileDownloadSas", _getFileDownloadSas.GetDownloadSasAsync);
+}

--- a/fkh-backend/GetFileUploadSasFunction.cs
+++ b/fkh-backend/GetFileUploadSasFunction.cs
@@ -1,0 +1,28 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class GetFileUploadSasFunction : FunctionBase
+{
+    private readonly ILogger<GetFileUploadSasFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhGetFileUploadSas _getFileUploadSas;
+
+    public GetFileUploadSasFunction(
+        ILogger<GetFileUploadSasFunction> logger,
+        GitHubAuthService gitHub,
+        FkhGetFileUploadSas getFileUploadSas)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _getFileUploadSas = getFileUploadSas;
+    }
+
+    [Function("GetFileUploadSas")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "GetFileUploadSas")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "GetFileUploadSas", _getFileUploadSas.GetUploadSasAsync);
+}

--- a/fkh-backend/Program.cs
+++ b/fkh-backend/Program.cs
@@ -36,6 +36,8 @@ var host = new HostBuilder()
         services.AddSingleton<FkhWaitForContainer>();
         services.AddSingleton<FkhGetDatabaseUploadSas>();
         services.AddSingleton<FkhGetDatabaseDownloadSas>();
+        services.AddSingleton<FkhGetFileUploadSas>();
+        services.AddSingleton<FkhGetFileDownloadSas>();
         services.AddSingleton<FkhBackupTenantDatabase>();
         services.AddSingleton<FkhRestoreTenantDatabase>();
         services.AddSingleton<FkhDismountTenant>();

--- a/fkh-backend/Services/FkhBlobContainerSasService.cs
+++ b/fkh-backend/Services/FkhBlobContainerSasService.cs
@@ -1,0 +1,54 @@
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Azure.Storage.Sas;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+public abstract class FkhBlobContainerSasService : FkhServiceBase
+{
+    protected FkhBlobContainerSasService(ILogger logger) : base(logger) { }
+
+    protected async Task<object> GetContainerSasAsync(
+        string containerName,
+        BlobSasPermissions permissions,
+        bool createIfNotExists,
+        string accessDescription,
+        Dictionary<string, string> parameters)
+    {
+#pragma warning disable CS0618
+        var credential = new ManagedIdentityCredential(ClientId);
+#pragma warning restore CS0618
+        var blobServiceClient = new BlobServiceClient(
+            new Uri($"https://{DbsStorageAccountName}.blob.core.windows.net"), credential);
+
+        var blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
+        if (createIfNotExists)
+            await blobContainerClient.CreateIfNotExistsAsync();
+
+        var expiresOn = DateTimeOffset.UtcNow.AddMinutes(60);
+        var delegationKey = await blobServiceClient.GetUserDelegationKeyAsync(DateTimeOffset.UtcNow, expiresOn);
+
+        var sasBuilder = new BlobSasBuilder
+        {
+            BlobContainerName = containerName,
+            Resource = "c",
+            ExpiresOn = expiresOn
+        };
+        sasBuilder.SetPermissions(permissions);
+
+        var sasToken = sasBuilder.ToSasQueryParameters(delegationKey, blobServiceClient.AccountName);
+        var sasUrl = $"https://{DbsStorageAccountName}.blob.core.windows.net/{containerName}?{sasToken}";
+
+        Logger.LogInformation("Generated 60-minute {AccessDescription} SAS for container '{ContainerName}' (user: {Username})",
+            accessDescription, containerName, parameters.GetValueOrDefault("_githubUsername", "unknown"));
+
+        return new
+        {
+            SasUrl = sasUrl,
+            ContainerName = containerName,
+            ExpiresInMinutes = 60,
+            StorageAccountName = DbsStorageAccountName
+        };
+    }
+}

--- a/fkh-backend/Services/FkhGetDatabaseUploadSas.cs
+++ b/fkh-backend/Services/FkhGetDatabaseUploadSas.cs
@@ -1,53 +1,20 @@
-using Azure.Identity;
-using Azure.Storage.Blobs;
 using Azure.Storage.Sas;
 using Microsoft.Extensions.Logging;
 
 namespace Fkh.Services;
 
-public class FkhGetDatabaseUploadSas : FkhServiceBase
+public class FkhGetDatabaseUploadSas : FkhBlobContainerSasService
 {
     public FkhGetDatabaseUploadSas(ILogger<FkhGetDatabaseUploadSas> logger) : base(logger) { }
 
     public async Task<object> GetUploadSasAsync(Dictionary<string, string> parameters)
     {
         var containerName = parameters.TryGetValue("containerName", out var cn) ? cn : "databases";
-
-#pragma warning disable CS0618
-        var credential = new ManagedIdentityCredential(ClientId);
-#pragma warning restore CS0618
-        var blobServiceClient = new BlobServiceClient(
-            new Uri($"https://{DbsStorageAccountName}.blob.core.windows.net"), credential);
-
-        // Ensure the blob container exists
-        var blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
-        await blobContainerClient.CreateIfNotExistsAsync();
-
-        // Generate a user-delegation SAS valid for 60 minutes with read, write, list permissions
-        var delegationKey = await blobServiceClient.GetUserDelegationKeyAsync(
-            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddMinutes(60));
-
-        var sasBuilder = new BlobSasBuilder
-        {
-            BlobContainerName = containerName,
-            Resource = "c", // container-level SAS
-            ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(60)
-        };
-        sasBuilder.SetPermissions(BlobSasPermissions.Read | BlobSasPermissions.Write | BlobSasPermissions.List);
-
-        var sasToken = sasBuilder.ToSasQueryParameters(delegationKey, blobServiceClient.AccountName);
-
-        var sasUrl = $"https://{DbsStorageAccountName}.blob.core.windows.net/{containerName}?{sasToken}";
-
-        Logger.LogInformation("Generated 60-minute upload SAS for container '{ContainerName}' (admin: {Username})",
-            containerName, parameters.GetValueOrDefault("_githubUsername", "unknown"));
-
-        return new
-        {
-            SasUrl = sasUrl,
-            ContainerName = containerName,
-            ExpiresInMinutes = 60,
-            StorageAccountName = DbsStorageAccountName
-        };
+        return await GetContainerSasAsync(
+            containerName,
+            BlobSasPermissions.Read | BlobSasPermissions.Write | BlobSasPermissions.List,
+            createIfNotExists: true,
+            accessDescription: "upload",
+            parameters);
     }
 }

--- a/fkh-backend/Services/FkhGetFileDownloadSas.cs
+++ b/fkh-backend/Services/FkhGetFileDownloadSas.cs
@@ -3,17 +3,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Fkh.Services;
 
-public class FkhGetDatabaseDownloadSas : FkhBlobContainerSasService
+public class FkhGetFileDownloadSas : FkhBlobContainerSasService
 {
-    public FkhGetDatabaseDownloadSas(ILogger<FkhGetDatabaseDownloadSas> logger) : base(logger) { }
+    public FkhGetFileDownloadSas(ILogger<FkhGetFileDownloadSas> logger) : base(logger) { }
 
     public async Task<object> GetDownloadSasAsync(Dictionary<string, string> parameters)
-    {
-        return await GetContainerSasAsync(
-            "databases",
+        => await GetContainerSasAsync(
+            "files",
             BlobSasPermissions.Read | BlobSasPermissions.List,
             createIfNotExists: false,
-            accessDescription: "read-only download",
+            accessDescription: "file read-only download",
             parameters);
-    }
 }

--- a/fkh-backend/Services/FkhGetFileUploadSas.cs
+++ b/fkh-backend/Services/FkhGetFileUploadSas.cs
@@ -1,0 +1,17 @@
+using Azure.Storage.Sas;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+public class FkhGetFileUploadSas : FkhBlobContainerSasService
+{
+    public FkhGetFileUploadSas(ILogger<FkhGetFileUploadSas> logger) : base(logger) { }
+
+    public async Task<object> GetUploadSasAsync(Dictionary<string, string> parameters)
+        => await GetContainerSasAsync(
+            "files",
+            BlobSasPermissions.Read | BlobSasPermissions.Write | BlobSasPermissions.List,
+            createIfNotExists: true,
+            accessDescription: "file upload",
+            parameters);
+}

--- a/fkh-cli/ClientCommand.cs
+++ b/fkh-cli/ClientCommand.cs
@@ -364,6 +364,8 @@ static class ClientCommands
         new PublishAppCommand(),
         new UploadDatabaseCommand(),
         new DownloadDatabaseCommand(),
+        new UploadFileCommand(),
+        new DownloadFileCommand(),
         new StatusCommand(),
         new OpenCommand(),
         new EditCommand(),

--- a/fkh-cli/Commands/CreateDeploymentRepoCommand.cs
+++ b/fkh-cli/Commands/CreateDeploymentRepoCommand.cs
@@ -24,6 +24,7 @@ sealed class CreateDeploymentRepoCommand : ClientCommand
 
         var fkhFullRepo = parameters.TryGetValue("fkhRepo", out var fr) && !string.IsNullOrWhiteSpace(fr) ? fr : "Freddy-DK/Fkh";
         var (fkhRepo, fkhBranch) = UpdateDeploymentRepoCommand.ParseFkhRepo(fkhFullRepo);
+        var requestedFkhBranch = fkhBranch;
 
         // 1. Verify gh is authenticated
         var (ghExit, _, ghErr) = RunProcess("gh", ["auth", "status"]);
@@ -74,7 +75,7 @@ sealed class CreateDeploymentRepoCommand : ClientCommand
         Console.WriteLine($"  Created: {createOut.Trim()}");
 
         // 5. Populate the repo with template files
-        var result = await UpdateDeploymentRepoCommand.UpdateDeploymentRepoAsync(deployFullRepo, fkhRepo, fkhBranch, "Initial deployment repo from Fkh template", quiet: true);
+        var result = await UpdateDeploymentRepoCommand.UpdateDeploymentRepoAsync(deployFullRepo, fkhRepo, fkhBranch, "Initial deployment repo from Fkh template", quiet: true, fkhVersionDefault: requestedFkhBranch);
         if (result != 0)
             return result;
 

--- a/fkh-cli/Commands/DownloadDatabaseCommand.cs
+++ b/fkh-cli/Commands/DownloadDatabaseCommand.cs
@@ -1,188 +1,32 @@
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
-
-sealed class DownloadDatabaseCommand : ClientCommand
+sealed class DownloadDatabaseCommand : VersionedBlobCommand
 {
     public override string Name => "DownloadDatabase";
-    public override string Description => "Downloads a database backup (.bak) from blob storage. Specify the database as 'name/version' (e.g. 'grmwithtests/latest').";
+    public override string Description => "Downloads a database backup (.bak) from blob storage. Specify the database as 'name/version' or just 'name' to use latest.";
     public override List<ClientCommandParameter> Parameters =>
     [
-        new() { Name = "database", Type = "string", Description = "Database to download as 'name/version' (e.g. 'grmwithtests/latest' or 'bhgwithtests/202604011126').", Required = true },
+        new() { Name = "database", Type = "string", Description = "Database to download as 'name/version' or just 'name' to use latest.", Required = true },
         new() { Name = "output", Type = "string", Description = "File path to save the downloaded .bak file. Defaults to 'name-version.bak' in the current directory.", Required = false }
     ];
 
-    public override async Task<int> ExecuteAsync(string[] args, CliSettings settings, bool asJson)
+    private static readonly DownloadSpec Spec = new()
     {
-        Dictionary<string, string> parameters;
-        try
+        ReferenceParameterName = "database",
+        ReferenceExample = "grmwithtests/latest",
+        OutputPathParameterName = "output",
+        SasFunctionName = "GetDatabaseDownloadSas",
+        ItemKind = "Database",
+        BlobDescription = "Database backup",
+        GetBlobName = static (name, version) => $"{name}/{version}.bak",
+        GetDefaultOutputPath = static (name, version) => $"{name}-{version}.bak",
+        CreateResult = static (name, version, fileName, sizeBytes) => new
         {
-            parameters = ParseClientArgs(args);
+            Database = name,
+            Version = version,
+            FileName = fileName,
+            SizeBytes = sizeBytes
         }
-        catch (InvalidOperationException ex)
-        {
-            Console.Error.WriteLine($"{Ansi.Red}{ex.Message}{Ansi.Reset}");
-            return 1;
-        }
+    };
 
-        if (!parameters.TryGetValue("database", out var database) || string.IsNullOrWhiteSpace(database))
-        {
-            Console.Error.WriteLine($"{Ansi.Red}Missing required parameter --database{Ansi.Reset}");
-            return 1;
-        }
-
-        var parts = database.Split('/', 2);
-        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
-        {
-            Console.Error.WriteLine($"{Ansi.Red}Invalid database value '{database}'. Expected 'name/version' (e.g. 'grmwithtests/latest' or 'bhgwithtests/202604011126').{Ansi.Reset}");
-            return 1;
-        }
-
-        var dbName = parts[0];
-        var dbVersion = parts[1];
-
-        parameters.TryGetValue("output", out var outputPath);
-
-        var token = CreateTokenProvider(parameters, settings).GetToken();
-        var backendUrl = ValidateBackendUrl(settings.BackendUrl);
-        if (backendUrl is null)
-            return 1;
-
-        // Step 1: Get read-only SAS URL from backend
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Dim}Requesting download SAS from backend...{Ansi.Reset}");
-
-        string sasUrl;
-        using (var httpClient = new HttpClient())
-        {
-            var sasRequest = new HttpRequestMessage(HttpMethod.Post, $"{backendUrl}/GetDatabaseDownloadSas");
-            sasRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            AddProtocolHeaders(sasRequest);
-            sasRequest.Content = new StringContent(
-                JsonSerializer.Serialize(new FunctionInvokeRequest
-                {
-                    Parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                }),
-                Encoding.UTF8, "application/json");
-
-            var sasResponse = await httpClient.SendAsync(sasRequest);
-            var sasBody = await sasResponse.Content.ReadAsStringAsync();
-
-            if (!sasResponse.IsSuccessStatusCode)
-            {
-                Console.Error.WriteLine($"{Ansi.Red}Failed to get SAS ({(int)sasResponse.StatusCode}): {sasBody}{Ansi.Reset}");
-                return 1;
-            }
-
-            using var doc = JsonDocument.Parse(sasBody);
-            sasUrl = doc.RootElement.GetProperty("sasUrl").GetString()
-                ?? throw new InvalidOperationException("Backend returned empty SAS URL.");
-        }
-
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Dim}SAS URL obtained (valid for 60 minutes).{Ansi.Reset}");
-
-        // Step 2: Read all.json manifest to resolve version
-        var containerUri = new Uri(sasUrl);
-        var containerClient = new Azure.Storage.Blobs.BlobContainerClient(containerUri);
-        var manifestBlobName = $"{dbName}/all.json";
-        var manifestClient = containerClient.GetBlobClient(manifestBlobName);
-
-        DatabaseManifest manifest;
-        try
-        {
-            var downloadResponse = await manifestClient.DownloadContentAsync();
-            var existingJson = downloadResponse.Value.Content.ToString();
-            manifest = JsonSerializer.Deserialize<DatabaseManifest>(existingJson,
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
-                ?? new DatabaseManifest();
-        }
-        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
-        {
-            Console.Error.WriteLine($"{Ansi.Red}No uploaded database named '{dbName}' found (missing {manifestBlobName}).{Ansi.Reset}");
-            return 1;
-        }
-
-        string resolvedVersion;
-        if (string.Equals(dbVersion, "latest", StringComparison.OrdinalIgnoreCase))
-        {
-            if (string.IsNullOrWhiteSpace(manifest.Latest))
-            {
-                Console.Error.WriteLine($"{Ansi.Red}Database '{dbName}' manifest has no 'latest' version.{Ansi.Reset}");
-                return 1;
-            }
-            resolvedVersion = manifest.Latest;
-        }
-        else
-        {
-            if (!manifest.Versions.Contains(dbVersion, StringComparer.OrdinalIgnoreCase))
-            {
-                Console.Error.WriteLine($"{Ansi.Red}Version '{dbVersion}' not found for database '{dbName}'. Available versions: {string.Join(", ", manifest.Versions)}{Ansi.Reset}");
-                return 1;
-            }
-            resolvedVersion = dbVersion;
-        }
-
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Dim}Resolved version: {resolvedVersion}{Ansi.Reset}");
-
-        // Step 3: Download the .bak blob
-        var blobName = $"{dbName}/{resolvedVersion}.bak";
-        var blobClient = containerClient.GetBlobClient(blobName);
-
-        if (!await blobClient.ExistsAsync())
-        {
-            Console.Error.WriteLine($"{Ansi.Red}Database backup blob '{blobName}' not found.{Ansi.Reset}");
-            return 1;
-        }
-
-        var fileName = outputPath ?? $"{dbName}-{resolvedVersion}.bak";
-
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Dim}Downloading {blobName}...{Ansi.Reset}");
-
-        var blobProperties = await blobClient.GetPropertiesAsync();
-        var totalBytes = blobProperties.Value.ContentLength;
-
-        await using (var blobStream = await blobClient.OpenReadAsync())
-        await using (var fileStream = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true))
-        {
-            var buffer = new byte[81920];
-            long totalRead = 0;
-            int bytesRead;
-            while ((bytesRead = await blobStream.ReadAsync(buffer)) > 0)
-            {
-                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead));
-                totalRead += bytesRead;
-                if (!asJson && totalBytes > 0)
-                {
-                    var pct = (double)totalRead / totalBytes * 100;
-                    Console.Write($"\r{Ansi.Dim}Downloaded {totalRead / (1024.0 * 1024):N1} / {totalBytes / (1024.0 * 1024):N1} MB ({pct:N0}%){Ansi.Reset}");
-                }
-            }
-
-            if (!asJson)
-                Console.WriteLine();
-        }
-
-        // Output result
-        var result = new
-        {
-            Database = dbName,
-            Version = resolvedVersion,
-            FileName = Path.GetFullPath(fileName),
-            SizeBytes = new FileInfo(fileName).Length
-        };
-
-        if (asJson)
-        {
-            Console.WriteLine(JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
-        }
-        else
-        {
-            Console.WriteLine($"{Ansi.Cyan}Done.{Ansi.Reset} Database '{dbName}' version '{resolvedVersion}' saved to {Path.GetFullPath(fileName)} ({result.SizeBytes / (1024.0 * 1024):N1} MB)");
-        }
-
-        return 0;
-    }
+    public override Task<int> ExecuteAsync(string[] args, CliSettings settings, bool asJson)
+        => DownloadVersionedBlobAsync(args, settings, asJson, Spec);
 }

--- a/fkh-cli/Commands/DownloadFileCommand.cs
+++ b/fkh-cli/Commands/DownloadFileCommand.cs
@@ -1,0 +1,26 @@
+sealed class DownloadFileCommand : VersionedBlobCommand
+{
+    public override string Name => "DownloadFile";
+    public override string Description => "Downloads a versioned file from blob storage. Specify the file as 'blob/version' or just 'blob' to use latest.";
+    public override List<ClientCommandParameter> Parameters =>
+    [
+        new() { Name = "file", Type = "string", Description = "File to download as 'blob/version' or just 'blob' to use latest.", Required = true },
+        new() { Name = "output", Type = "string", Description = "File path to save the downloaded file. Defaults to 'blob-version' in the current directory.", Required = false }
+    ];
+
+    private static readonly DownloadSpec Spec = new()
+    {
+        ReferenceParameterName = "file",
+        ReferenceFormat = "blob/version",
+        ReferenceExample = "myfile/latest",
+        OutputPathParameterName = "output",
+        SasFunctionName = "GetFileDownloadSas",
+        ItemKind = "File",
+        BlobDescription = "File",
+        GetBlobName = static (name, version) => $"{name}/{version}",
+        GetDefaultOutputPath = static (name, version) => $"{name}-{version}"
+    };
+
+    public override Task<int> ExecuteAsync(string[] args, CliSettings settings, bool asJson)
+        => DownloadVersionedBlobAsync(args, settings, asJson, Spec);
+}

--- a/fkh-cli/Commands/UpdateDeploymentRepoCommand.cs
+++ b/fkh-cli/Commands/UpdateDeploymentRepoCommand.cs
@@ -25,6 +25,7 @@ sealed class UpdateDeploymentRepoCommand : ClientCommand
 
         var fkhFullRepo = parameters.TryGetValue("fkhRepo", out var fr) && !string.IsNullOrWhiteSpace(fr) ? fr : "Freddy-DK/Fkh";
         var (fkhRepo, fkhBranch) = ParseFkhRepo(fkhFullRepo);
+        var requestedFkhBranch = fkhBranch;
 
         // Verify gh is authenticated
         var (ghExit, _, ghErr) = RunProcess("gh", ["auth", "status"]);
@@ -71,14 +72,14 @@ sealed class UpdateDeploymentRepoCommand : ClientCommand
             Console.WriteLine();
         }
 
-        return await UpdateDeploymentRepoAsync(deployFullRepo, fkhRepo, fkhBranch, "Update deployment repo from Fkh template");
+        return await UpdateDeploymentRepoAsync(deployFullRepo, fkhRepo, fkhBranch, "Update deployment repo from Fkh template", fkhVersionDefault: requestedFkhBranch);
     }
 
     /// <summary>
     /// Clones the deployment repo, fetches template files from the Fkh fork,
     /// writes them (skipping deployment.tfvars), commits and pushes.
     /// </summary>
-    internal static async Task<int> UpdateDeploymentRepoAsync(string deployFullRepo, string fkhRepo, string fkhBranch, string commitMessage, bool quiet = false)
+    internal static async Task<int> UpdateDeploymentRepoAsync(string deployFullRepo, string fkhRepo, string fkhBranch, string commitMessage, bool quiet = false, string? fkhVersionDefault = null)
     {
         // 1. Verify gh is authenticated
         var (ghExit, _, ghErr) = RunProcess("gh", ["auth", "status"]);
@@ -154,6 +155,8 @@ sealed class UpdateDeploymentRepoCommand : ClientCommand
                     content = content.Replace("Freddy-DK/Fkh", fkhRepo);
                     content = content.Replace("@main", $"@{fkhBranch}");
                     content = content.Replace("fkh-ref: main", $"fkh-ref: {fkhBranch}");
+                    if (relativePath.Equals(".github/workflows/UpdateFkhVersion.yml", StringComparison.OrdinalIgnoreCase))
+                        content = SetWorkflowInputDefault(content, "fkh-version", fkhVersionDefault ?? fkhBranch);
                 }
 
                 var targetPath = Path.Combine(tempDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
@@ -238,6 +241,47 @@ sealed class UpdateDeploymentRepoCommand : ClientCommand
             return (fkhFullRepo[..atIndex], fkhFullRepo[(atIndex + 1)..]);
         return (fkhFullRepo, "latest");
     }
+
+    static string SetWorkflowInputDefault(string content, string inputName, string defaultValue)
+    {
+        var lines = content.Replace("\r\n", "\n").Split('\n');
+        var inInput = false;
+        var inputIndent = -1;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var trimmed = line.TrimStart();
+            var indent = line.Length - trimmed.Length;
+
+            if (trimmed.StartsWith($"{inputName}:", StringComparison.Ordinal))
+            {
+                inInput = true;
+                inputIndent = indent;
+                continue;
+            }
+
+            if (!inInput)
+                continue;
+
+            if (trimmed.Length > 0 && indent <= inputIndent)
+            {
+                inInput = false;
+                continue;
+            }
+
+            if (trimmed.StartsWith("default:", StringComparison.Ordinal))
+            {
+                var prefix = line[..indent];
+                lines[i] = $"{prefix}default: {ToSingleQuotedYaml(defaultValue)}";
+                break;
+            }
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    static string ToSingleQuotedYaml(string value) => $"'{value.Replace("'", "''")}'";
 
     /// <summary>
     /// Resolves "latest" and "preview" branch aliases to actual release tags from the given repo.

--- a/fkh-cli/Commands/UploadDatabaseCommand.cs
+++ b/fkh-cli/Commands/UploadDatabaseCommand.cs
@@ -1,9 +1,4 @@
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
-sealed class UploadDatabaseCommand : ClientCommand
+sealed class UploadDatabaseCommand : VersionedBlobCommand
 {
     public override string Name => "UploadDatabase";
     public override string Description => "Uploads a .bak database file to blob storage. Updates a version manifest (all.json) with all versions and the latest. Admin only.";
@@ -14,186 +9,21 @@ sealed class UploadDatabaseCommand : ClientCommand
         new() { Name = "backupVersion", Type = "string", Description = "Version label for this backup (used as the blob name).", Required = true }
     ];
 
-    public override async Task<int> ExecuteAsync(string[] args, CliSettings settings, bool asJson)
+    private static readonly UploadSpec Spec = new()
     {
-        Dictionary<string, string> parameters;
-        try
+        LocalPathParameterName = "bakFile",
+        NameParameterName = "backupName",
+        VersionParameterName = "backupVersion",
+        SasFunctionName = "GetDatabaseUploadSas",
+        ItemKind = "Database",
+        BlobDescription = "Database backup",
+        GetBlobName = static (name, version) => $"{name}/{version}.bak",
+        SasParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            parameters = ParseClientArgs(args);
+            ["containerName"] = "databases"
         }
-        catch (InvalidOperationException ex)
-        {
-            Console.Error.WriteLine($"{Ansi.Red}{ex.Message}{Ansi.Reset}");
-            return 1;
-        }
+    };
 
-        if (!parameters.TryGetValue("backupName", out var name) || string.IsNullOrWhiteSpace(name))
-        {
-            Console.Error.WriteLine($"{Ansi.Red}Missing required parameter --backupName{Ansi.Reset}");
-            return 1;
-        }
-        if (!parameters.TryGetValue("backupVersion", out var version) || string.IsNullOrWhiteSpace(version))
-        {
-            Console.Error.WriteLine($"{Ansi.Red}Missing required parameter --backupVersion{Ansi.Reset}");
-            return 1;
-        }
-        if (!parameters.TryGetValue("bakFile", out var bakFile) || string.IsNullOrWhiteSpace(bakFile))
-        {
-            Console.Error.WriteLine($"{Ansi.Red}Missing required parameter --bakFile{Ansi.Reset}");
-            return 1;
-        }
-        if (!File.Exists(bakFile))
-        {
-            Console.Error.WriteLine($"{Ansi.Red}File not found: {bakFile}{Ansi.Reset}");
-            return 1;
-        }
-
-        var token = CreateTokenProvider(parameters, settings).GetToken();
-        var backendUrl = ValidateBackendUrl(settings.BackendUrl);
-        if (backendUrl is null)
-            return 1;
-
-        // Step 1: Get SAS URL from backend (admin-only endpoint, not in catalog)
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Dim}Requesting upload SAS from backend...{Ansi.Reset}");
-
-        string sasUrl;
-        using (var httpClient = new HttpClient())
-        {
-            var sasRequest = new HttpRequestMessage(HttpMethod.Post, $"{backendUrl}/GetDatabaseUploadSas");
-            sasRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            AddProtocolHeaders(sasRequest);
-            sasRequest.Content = new StringContent(
-                JsonSerializer.Serialize(new FunctionInvokeRequest
-                {
-                    Parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        ["containerName"] = "databases"
-                    }
-                }),
-                Encoding.UTF8, "application/json");
-
-            var sasResponse = await httpClient.SendAsync(sasRequest);
-            var sasBody = await sasResponse.Content.ReadAsStringAsync();
-
-            if (!sasResponse.IsSuccessStatusCode)
-            {
-                Console.Error.WriteLine($"{Ansi.Red}Failed to get upload SAS ({(int)sasResponse.StatusCode}): {sasBody}{Ansi.Reset}");
-                return 1;
-            }
-
-            using var doc = JsonDocument.Parse(sasBody);
-            sasUrl = doc.RootElement.GetProperty("sasUrl").GetString()
-                ?? throw new InvalidOperationException("Backend returned empty SAS URL.");
-        }
-
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Dim}SAS URL obtained (valid for 60 minutes).{Ansi.Reset}");
-
-        // Step 2: Upload the .bak file directly to blob storage
-        var blobName = $"{name}/{version}.bak";
-        var fileSize = new FileInfo(bakFile).Length;
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Dim}Uploading {bakFile} ({fileSize / (1024.0 * 1024):N3} Mb) as {blobName}...{Ansi.Reset}");
-
-        var containerUri = new Uri(sasUrl);
-        var containerClient = new Azure.Storage.Blobs.BlobContainerClient(containerUri);
-        var blobClient = containerClient.GetBlobClient(blobName);
-
-        await using (var fileStream = File.OpenRead(bakFile))
-        await using (var blobStream = await blobClient.OpenWriteAsync(overwrite: true))
-        {
-            var buffer = new byte[81920];
-            long totalWritten = 0;
-            int bytesRead;
-            while ((bytesRead = await fileStream.ReadAsync(buffer)) > 0)
-            {
-                await blobStream.WriteAsync(buffer.AsMemory(0, bytesRead));
-                totalWritten += bytesRead;
-                if (!asJson && fileSize > 0)
-                {
-                    var pct = (double)totalWritten / fileSize * 100;
-                    Console.Write($"\r{Ansi.Dim}Uploaded {totalWritten / (1024.0 * 1024):N1} / {fileSize / (1024.0 * 1024):N1} MB ({pct:N0}%){Ansi.Reset}");
-                }
-            }
-
-            if (!asJson)
-                Console.WriteLine();
-        }
-
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Cyan}Uploaded:{Ansi.Reset} {blobName}");
-
-        // Step 3: Update all.json manifest
-        var manifestBlobName = $"{name}/all.json";
-        var manifestClient = containerClient.GetBlobClient(manifestBlobName);
-
-        DatabaseManifest manifest;
-        try
-        {
-            var downloadResponse = await manifestClient.DownloadContentAsync();
-            var existingJson = downloadResponse.Value.Content.ToString();
-            manifest = JsonSerializer.Deserialize<DatabaseManifest>(existingJson,
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
-                ?? new DatabaseManifest();
-        }
-        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
-        {
-            manifest = new DatabaseManifest();
-        }
-
-        // Add version if not already present
-        if (!manifest.Versions.Contains(version, StringComparer.OrdinalIgnoreCase))
-        {
-            manifest.Versions.Add(version);
-        }
-        manifest.Latest = version;
-
-        var manifestJson = JsonSerializer.Serialize(manifest, new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        });
-
-        using (var manifestStream = new MemoryStream(Encoding.UTF8.GetBytes(manifestJson)))
-        {
-            await manifestClient.UploadAsync(manifestStream, overwrite: true);
-        }
-
-        if (!asJson)
-            Console.WriteLine($"{Ansi.Cyan}Updated:{Ansi.Reset} {manifestBlobName}");
-
-        // Output result
-        var result = new
-        {
-            Name = name,
-            Version = version,
-            BlobName = blobName,
-            Manifest = manifestBlobName,
-            Versions = manifest.Versions,
-            Latest = manifest.Latest
-        };
-
-        if (asJson)
-        {
-            Console.WriteLine(JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
-        }
-        else
-        {
-            Console.WriteLine($"{Ansi.Cyan}Done.{Ansi.Reset} Database '{name}' version '{version}' uploaded successfully.");
-            Console.WriteLine($"  Versions: {string.Join(", ", manifest.Versions)}");
-            Console.WriteLine($"  Latest: {manifest.Latest}");
-        }
-
-        return 0;
-    }
-}
-
-sealed class DatabaseManifest
-{
-    [JsonPropertyName("versions")]
-    public List<string> Versions { get; set; } = new();
-
-    [JsonPropertyName("latest")]
-    public string? Latest { get; set; }
+    public override Task<int> ExecuteAsync(string[] args, CliSettings settings, bool asJson)
+        => UploadVersionedBlobAsync(args, settings, asJson, Spec);
 }

--- a/fkh-cli/Commands/UploadFileCommand.cs
+++ b/fkh-cli/Commands/UploadFileCommand.cs
@@ -1,0 +1,25 @@
+sealed class UploadFileCommand : VersionedBlobCommand
+{
+    public override string Name => "UploadFile";
+    public override string Description => "Uploads a local file to blob storage. Updates a version manifest (all.json) with all versions and the latest. Admin only.";
+    public override List<ClientCommandParameter> Parameters =>
+    [
+        new() { Name = "localPath", Type = "file", Description = "Path to the local file to upload.", Required = true },
+        new() { Name = "FileName", Type = "string", Description = "File name (used as the folder name in blob storage).", Required = true },
+        new() { Name = "FileVersion", Type = "string", Description = "Version label for this file (used as the blob name).", Required = true }
+    ];
+
+    private static readonly UploadSpec Spec = new()
+    {
+        LocalPathParameterName = "localPath",
+        NameParameterName = "FileName",
+        VersionParameterName = "FileVersion",
+        SasFunctionName = "GetFileUploadSas",
+        ItemKind = "File",
+        BlobDescription = "File",
+        GetBlobName = static (name, version) => $"{name}/{version}"
+    };
+
+    public override Task<int> ExecuteAsync(string[] args, CliSettings settings, bool asJson)
+        => UploadVersionedBlobAsync(args, settings, asJson, Spec);
+}

--- a/fkh-cli/Commands/VersionedBlobCommand.cs
+++ b/fkh-cli/Commands/VersionedBlobCommand.cs
@@ -1,0 +1,398 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+abstract class VersionedBlobCommand : ClientCommand
+{
+    protected sealed class UploadSpec
+    {
+        public required string LocalPathParameterName { get; init; }
+        public required string NameParameterName { get; init; }
+        public required string VersionParameterName { get; init; }
+        public required string SasFunctionName { get; init; }
+        public required string ItemKind { get; init; }
+        public required string BlobDescription { get; init; }
+        public required Func<string, string, string> GetBlobName { get; init; }
+        public Dictionary<string, string> SasParameters { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    protected sealed class DownloadSpec
+    {
+        public string? ReferenceParameterName { get; init; }
+        public string? ReferenceExample { get; init; }
+        public string ReferenceFormat { get; init; } = "name/version";
+        public string DefaultVersion { get; init; } = "latest";
+        public string? NameParameterName { get; init; }
+        public string? VersionParameterName { get; init; }
+        public string? OutputPathParameterName { get; init; }
+        public bool OutputPathRequired { get; init; }
+        public required string SasFunctionName { get; init; }
+        public required string ItemKind { get; init; }
+        public required string BlobDescription { get; init; }
+        public required Func<string, string, string> GetBlobName { get; init; }
+        public required Func<string, string, string> GetDefaultOutputPath { get; init; }
+        public Func<string, string, string, long, object>? CreateResult { get; init; }
+        public Dictionary<string, string> SasParameters { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    protected async Task<int> UploadVersionedBlobAsync(string[] args, CliSettings settings, bool asJson, UploadSpec spec)
+    {
+        if (!TryParseClientArgs(args, out var parameters))
+            return 1;
+
+        if (!TryGetRequiredParameter(parameters, spec.NameParameterName, out var name))
+            return 1;
+        if (!TryGetRequiredParameter(parameters, spec.VersionParameterName, out var version))
+            return 1;
+        if (!TryGetRequiredParameter(parameters, spec.LocalPathParameterName, out var localPath))
+            return 1;
+        if (!File.Exists(localPath))
+        {
+            Console.Error.WriteLine($"{Ansi.Red}File not found: {localPath}{Ansi.Reset}");
+            return 1;
+        }
+
+        var token = CreateTokenProvider(parameters, settings).GetToken();
+        var backendUrl = ValidateBackendUrl(settings.BackendUrl);
+        if (backendUrl is null)
+            return 1;
+
+        var sasUrl = await RequestSasUrlAsync(backendUrl, token, spec.SasFunctionName, spec.SasParameters, "upload", asJson);
+        if (sasUrl is null)
+            return 1;
+
+        var blobName = spec.GetBlobName(name, version);
+        var fileSize = new FileInfo(localPath).Length;
+        if (!asJson)
+            Console.WriteLine($"{Ansi.Dim}Uploading {localPath} ({fileSize / (1024.0 * 1024):N3} Mb) as {blobName}...{Ansi.Reset}");
+
+        var containerClient = new Azure.Storage.Blobs.BlobContainerClient(new Uri(sasUrl));
+        var blobClient = containerClient.GetBlobClient(blobName);
+
+        await using (var fileStream = File.OpenRead(localPath))
+        await using (var blobStream = await blobClient.OpenWriteAsync(overwrite: true))
+        {
+            var buffer = new byte[81920];
+            long totalWritten = 0;
+            int bytesRead;
+            while ((bytesRead = await fileStream.ReadAsync(buffer)) > 0)
+            {
+                await blobStream.WriteAsync(buffer.AsMemory(0, bytesRead));
+                totalWritten += bytesRead;
+                if (!asJson && fileSize > 0)
+                {
+                    var pct = (double)totalWritten / fileSize * 100;
+                    Console.Write($"\r{Ansi.Dim}Uploaded {totalWritten / (1024.0 * 1024):N1} / {fileSize / (1024.0 * 1024):N1} MB ({pct:N0}%){Ansi.Reset}");
+                }
+            }
+
+            if (!asJson)
+                Console.WriteLine();
+        }
+
+        if (!asJson)
+            Console.WriteLine($"{Ansi.Cyan}Uploaded:{Ansi.Reset} {blobName}");
+
+        var manifestBlobName = $"{name}/all.json";
+        var manifestClient = containerClient.GetBlobClient(manifestBlobName);
+        var manifest = await DownloadManifestAsync(manifestClient) ?? new VersionedBlobManifest();
+
+        if (!manifest.Versions.Contains(version, StringComparer.OrdinalIgnoreCase))
+            manifest.Versions.Add(version);
+        manifest.Latest = version;
+
+        await UploadManifestAsync(manifestClient, manifest);
+
+        if (!asJson)
+            Console.WriteLine($"{Ansi.Cyan}Updated:{Ansi.Reset} {manifestBlobName}");
+
+        var result = new
+        {
+            Name = name,
+            Version = version,
+            BlobName = blobName,
+            Manifest = manifestBlobName,
+            Versions = manifest.Versions,
+            Latest = manifest.Latest
+        };
+
+        if (asJson)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            Console.WriteLine($"{Ansi.Cyan}Done.{Ansi.Reset} {spec.ItemKind} '{name}' version '{version}' uploaded successfully.");
+            Console.WriteLine($"  Versions: {string.Join(", ", manifest.Versions)}");
+            Console.WriteLine($"  Latest: {manifest.Latest}");
+        }
+
+        return 0;
+    }
+
+    protected async Task<int> DownloadVersionedBlobAsync(string[] args, CliSettings settings, bool asJson, DownloadSpec spec)
+    {
+        if (!TryParseClientArgs(args, out var parameters))
+            return 1;
+
+        if (!TryResolveDownloadReference(parameters, spec, out var name, out var version, out var outputPath))
+            return 1;
+
+        var token = CreateTokenProvider(parameters, settings).GetToken();
+        var backendUrl = ValidateBackendUrl(settings.BackendUrl);
+        if (backendUrl is null)
+            return 1;
+
+        var sasUrl = await RequestSasUrlAsync(backendUrl, token, spec.SasFunctionName, spec.SasParameters, "download", asJson);
+        if (sasUrl is null)
+            return 1;
+
+        var containerClient = new Azure.Storage.Blobs.BlobContainerClient(new Uri(sasUrl));
+        var manifestBlobName = $"{name}/all.json";
+        var manifestClient = containerClient.GetBlobClient(manifestBlobName);
+        var manifest = await DownloadManifestAsync(manifestClient);
+        if (manifest is null)
+        {
+            Console.Error.WriteLine($"{Ansi.Red}No uploaded {spec.ItemKind.ToLowerInvariant()} named '{name}' found (missing {manifestBlobName}).{Ansi.Reset}");
+            return 1;
+        }
+
+        if (!TryResolveVersion(name, version, manifest, spec.ItemKind, out var resolvedVersion))
+            return 1;
+
+        if (!asJson)
+            Console.WriteLine($"{Ansi.Dim}Resolved version: {resolvedVersion}{Ansi.Reset}");
+
+        var blobName = spec.GetBlobName(name, resolvedVersion);
+        var blobClient = containerClient.GetBlobClient(blobName);
+
+        if (!await blobClient.ExistsAsync())
+        {
+            Console.Error.WriteLine($"{Ansi.Red}{spec.BlobDescription} blob '{blobName}' not found.{Ansi.Reset}");
+            return 1;
+        }
+
+        var localPath = outputPath ?? spec.GetDefaultOutputPath(name, resolvedVersion);
+
+        if (!asJson)
+            Console.WriteLine($"{Ansi.Dim}Downloading {blobName}...{Ansi.Reset}");
+
+        var blobProperties = await blobClient.GetPropertiesAsync();
+        var totalBytes = blobProperties.Value.ContentLength;
+
+        await using (var blobStream = await blobClient.OpenReadAsync())
+        await using (var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true))
+        {
+            var buffer = new byte[81920];
+            long totalRead = 0;
+            int bytesRead;
+            while ((bytesRead = await blobStream.ReadAsync(buffer)) > 0)
+            {
+                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead));
+                totalRead += bytesRead;
+                if (!asJson && totalBytes > 0)
+                {
+                    var pct = (double)totalRead / totalBytes * 100;
+                    Console.Write($"\r{Ansi.Dim}Downloaded {totalRead / (1024.0 * 1024):N1} / {totalBytes / (1024.0 * 1024):N1} MB ({pct:N0}%){Ansi.Reset}");
+                }
+            }
+
+            if (!asJson)
+                Console.WriteLine();
+        }
+
+        var fullPath = Path.GetFullPath(localPath);
+        var sizeBytes = new FileInfo(localPath).Length;
+        var result = spec.CreateResult?.Invoke(name, resolvedVersion, fullPath, sizeBytes)
+            ?? new
+            {
+                Name = name,
+                Version = resolvedVersion,
+                FileName = fullPath,
+                SizeBytes = sizeBytes
+            };
+
+        if (asJson)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            Console.WriteLine($"{Ansi.Cyan}Done.{Ansi.Reset} {spec.ItemKind} '{name}' version '{resolvedVersion}' saved to {fullPath} ({sizeBytes / (1024.0 * 1024):N1} MB)");
+        }
+
+        return 0;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static bool TryParseClientArgs(string[] args, out Dictionary<string, string> parameters)
+    {
+        try
+        {
+            parameters = ParseClientArgs(args);
+            return true;
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine($"{Ansi.Red}{ex.Message}{Ansi.Reset}");
+            parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            return false;
+        }
+    }
+
+    private static bool TryGetRequiredParameter(Dictionary<string, string> parameters, string parameterName, out string value)
+    {
+        if (!parameters.TryGetValue(parameterName, out value!) || string.IsNullOrWhiteSpace(value))
+        {
+            Console.Error.WriteLine($"{Ansi.Red}Missing required parameter --{parameterName}{Ansi.Reset}");
+            value = string.Empty;
+            return false;
+        }
+        return true;
+    }
+
+    private static bool TryResolveDownloadReference(Dictionary<string, string> parameters, DownloadSpec spec, out string name, out string version, out string? outputPath)
+    {
+        name = string.Empty;
+        version = string.Empty;
+        outputPath = null;
+
+        if (!string.IsNullOrWhiteSpace(spec.ReferenceParameterName))
+        {
+            if (!TryGetRequiredParameter(parameters, spec.ReferenceParameterName, out var reference))
+            {
+                return false;
+            }
+
+            var parts = reference.Split('/', 2);
+            if (string.IsNullOrWhiteSpace(parts[0]) || (parts.Length == 2 && string.IsNullOrWhiteSpace(parts[1])))
+            {
+                Console.Error.WriteLine($"{Ansi.Red}Invalid {spec.ReferenceParameterName} value '{reference}'. Expected '{spec.ReferenceFormat}' or a name without version to use '{spec.DefaultVersion}' (e.g. '{spec.ReferenceExample}').{Ansi.Reset}");
+                return false;
+            }
+
+            name = parts[0];
+            version = parts.Length == 2 ? parts[1] : spec.DefaultVersion;
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(spec.NameParameterName) || !TryGetRequiredParameter(parameters, spec.NameParameterName, out name))
+            {
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(spec.VersionParameterName) || !TryGetRequiredParameter(parameters, spec.VersionParameterName, out version))
+                return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(spec.OutputPathParameterName))
+        {
+            parameters.TryGetValue(spec.OutputPathParameterName, out outputPath);
+            if (spec.OutputPathRequired && string.IsNullOrWhiteSpace(outputPath))
+            {
+                Console.Error.WriteLine($"{Ansi.Red}Missing required parameter --{spec.OutputPathParameterName}{Ansi.Reset}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveVersion(string name, string version, VersionedBlobManifest manifest, string itemKind, out string resolvedVersion)
+    {
+        if (string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(manifest.Latest))
+            {
+                Console.Error.WriteLine($"{Ansi.Red}{itemKind} '{name}' manifest has no 'latest' version.{Ansi.Reset}");
+                resolvedVersion = string.Empty;
+                return false;
+            }
+            resolvedVersion = manifest.Latest;
+            return true;
+        }
+
+        if (!manifest.Versions.Contains(version, StringComparer.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine($"{Ansi.Red}Version '{version}' not found for {itemKind.ToLowerInvariant()} '{name}'. Available versions: {string.Join(", ", manifest.Versions)}{Ansi.Reset}");
+            resolvedVersion = string.Empty;
+            return false;
+        }
+
+        resolvedVersion = version;
+        return true;
+    }
+
+    private static async Task<string?> RequestSasUrlAsync(string backendUrl, string token, string sasFunctionName, Dictionary<string, string> sasParameters, string action, bool asJson)
+    {
+        if (!asJson)
+            Console.WriteLine($"{Ansi.Dim}Requesting {action} SAS from backend...{Ansi.Reset}");
+
+        using var httpClient = new HttpClient();
+        var sasRequest = new HttpRequestMessage(HttpMethod.Post, $"{backendUrl}/{sasFunctionName}");
+        sasRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        AddProtocolHeaders(sasRequest);
+        sasRequest.Content = new StringContent(
+            JsonSerializer.Serialize(new FunctionInvokeRequest
+            {
+                Parameters = sasParameters
+            }),
+            Encoding.UTF8, "application/json");
+
+        var sasResponse = await httpClient.SendAsync(sasRequest);
+        var sasBody = await sasResponse.Content.ReadAsStringAsync();
+
+        if (!sasResponse.IsSuccessStatusCode)
+        {
+            Console.Error.WriteLine($"{Ansi.Red}Failed to get {action} SAS ({(int)sasResponse.StatusCode}): {sasBody}{Ansi.Reset}");
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(sasBody);
+        var sasUrl = doc.RootElement.GetProperty("sasUrl").GetString();
+        if (string.IsNullOrWhiteSpace(sasUrl))
+            throw new InvalidOperationException("Backend returned empty SAS URL.");
+
+        if (!asJson)
+            Console.WriteLine($"{Ansi.Dim}SAS URL obtained (valid for 60 minutes).{Ansi.Reset}");
+
+        return sasUrl;
+    }
+
+    private static async Task<VersionedBlobManifest?> DownloadManifestAsync(Azure.Storage.Blobs.BlobClient manifestClient)
+    {
+        try
+        {
+            var downloadResponse = await manifestClient.DownloadContentAsync();
+            var existingJson = downloadResponse.Value.Content.ToString();
+            return JsonSerializer.Deserialize<VersionedBlobManifest>(existingJson,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? new VersionedBlobManifest();
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    private static async Task UploadManifestAsync(Azure.Storage.Blobs.BlobClient manifestClient, VersionedBlobManifest manifest)
+    {
+        var manifestJson = JsonSerializer.Serialize(manifest, JsonOptions);
+        using var manifestStream = new MemoryStream(Encoding.UTF8.GetBytes(manifestJson));
+        await manifestClient.UploadAsync(manifestStream, overwrite: true);
+    }
+}
+
+sealed class VersionedBlobManifest
+{
+    [JsonPropertyName("versions")]
+    public List<string> Versions { get; set; } = new();
+
+    [JsonPropertyName("latest")]
+    public string? Latest { get; set; }
+}


### PR DESCRIPTION
This pull request adds support for uploading and downloading versioned files (not just databases) via new backend API endpoints and CLI commands. It also refactors the SAS (Shared Access Signature) generation logic for both databases and files into a reusable service, simplifying and unifying the code. The CLI logic for downloading databases is also generalized to support both databases and files.

**New File Upload/Download Functionality:**

* Added new backend endpoints `GetFileUploadSas` and `GetFileDownloadSas` for uploading and downloading versioned files, with corresponding Azure Function handlers (`GetFileUploadSasFunction.cs`, `GetFileDownloadSasFunction.cs`). These endpoints generate SAS URLs for secure file operations. [[1]](diffhunk://#diff-f0c2060470011947e4924425059d7cc0f538d778b53b80bcc4b21baa7e88bdd4R223-R224) [[2]](diffhunk://#diff-f0c2060470011947e4924425059d7cc0f538d778b53b80bcc4b21baa7e88bdd4R443-R450) [[3]](diffhunk://#diff-133b3defff5b66955ec9b12d74ee56829b30e45d385c2ab8a139a3d2cecd9145R597-R613) [[4]](diffhunk://#diff-8c0c1b6f946abb10e023262c974681ffb626897909d13c7ac6432dade52cdadeR1-R28) [[5]](diffhunk://#diff-47dc757772b691c942668ee5c40047ba47ae95cba75f812c6fff549c09be76a1R1-R28) [[6]](diffhunk://#diff-2fe97b39319a8b0bf6bf698037089185bbf8c0fd2c752002633a770249b5e085R1-R17) [[7]](diffhunk://#diff-4348ebe78b7efaae25af74dd85d0a493bc91917fd1ea97d8c8bd74d0ec0c048fR1-R17)
* Registered new services `FkhGetFileUploadSas` and `FkhGetFileDownloadSas` for dependency injection in the backend.
* Added new CLI commands `UploadFileCommand` and `DownloadFileCommand` to support file upload/download from the command line.

**Codebase Refactoring and Simplification:**

* Introduced `FkhBlobContainerSasService`, a base service that encapsulates the logic for generating container-level SAS URLs, now used by both database and file SAS services. This removes duplicated code and centralizes SAS logic. [[1]](diffhunk://#diff-f102ba2e7ad2918022216d6c5e7fa4670e13474ac74d76726e4e7cdf6591eed8R1-R54) [[2]](diffhunk://#diff-ad16099e08c9804512a49727229e1c140e241292a1915ac770b0d7268d4ddd8eL1-R17) [[3]](diffhunk://#diff-1e9d2d1316c8641dc21715fb344b85188a2cfe3108764085f5cab6a639b4a0beL1-R18) [[4]](diffhunk://#diff-2fe97b39319a8b0bf6bf698037089185bbf8c0fd2c752002633a770249b5e085R1-R17) [[5]](diffhunk://#diff-4348ebe78b7efaae25af74dd85d0a493bc91917fd1ea97d8c8bd74d0ec0c048fR1-R17)
* Refactored the CLI `DownloadDatabaseCommand` to inherit from a new `VersionedBlobCommand` base, generalizing the download logic for use by both databases and files.

**API Documentation Updates:**

* Updated `.github/api-v1-contract.md` to document the new endpoints and their parameters. [[1]](diffhunk://#diff-f0c2060470011947e4924425059d7cc0f538d778b53b80bcc4b21baa7e88bdd4R223-R224) [[2]](diffhunk://#diff-f0c2060470011947e4924425059d7cc0f538d778b53b80bcc4b21baa7e88bdd4R443-R450)

These changes make it easier to add support for additional blob-backed resources in the future and provide a unified, secure mechanism for managing versioned files and databases.