### PR TITLE
Add removedatabase, removefile, listdatabases and listfiles

### DIFF
--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -612,6 +612,76 @@ public static class FunctionCatalog
         },
         new FunctionDefinition
         {
+            Name = "RemoveDatabase",
+            Description = "Removes an uploaded database backup version from blob storage and updates the version manifest (all.json). Specify the database as 'name/version', or just 'name' to remove the latest version (latest is then repointed to the previous version). Admin only.",
+            Route = "RemoveDatabase",
+            AdminOnly = true,
+            RequiresConfirmation = true,
+            Parameters = new List<FunctionParameterDefinition>
+            {
+                new()
+                {
+                    Name = "database",
+                    Type = "string",
+                    Description = "Database to remove as 'name/version', or just 'name' to remove the latest version.",
+                    Required = true
+                }
+            }
+        },
+        new FunctionDefinition
+        {
+            Name = "RemoveFile",
+            Description = "Removes an uploaded file version from blob storage and updates the version manifest (all.json). Specify the file as 'name/version', or just 'name' to remove the latest version (latest is then repointed to the previous version). Admin only.",
+            Route = "RemoveFile",
+            AdminOnly = true,
+            RequiresConfirmation = true,
+            Parameters = new List<FunctionParameterDefinition>
+            {
+                new()
+                {
+                    Name = "file",
+                    Type = "string",
+                    Description = "File to remove as 'name/version', or just 'name' to remove the latest version.",
+                    Required = true
+                }
+            }
+        },
+        new FunctionDefinition
+        {
+            Name = "ListDatabases",
+            Description = "Lists uploaded database backups in blob storage. Filter with 'name/version' where both sides support '*' (any characters) and '?' (single character) wildcards: '*/latest' (default) lists the latest version of every database, '*/*' lists all versions of all databases, 'name/*' lists all versions of a database, and patterns like 'My*/latest' or 'cronus??/*' are supported. 'version' also accepts the keyword 'latest'.",
+            Route = "ListDatabases",
+            Parameters = new List<FunctionParameterDefinition>
+            {
+                new()
+                {
+                    Name = "database",
+                    Type = "string",
+                    Description = "Filter as 'name/version'. Both sides support '*' and '?' wildcards; 'version' also accepts 'latest'. Defaults to '*/latest'.",
+                    Required = false,
+                    DefaultValue = "*/latest"
+                }
+            }
+        },
+        new FunctionDefinition
+        {
+            Name = "ListFiles",
+            Description = "Lists uploaded files in blob storage. Filter with 'name/version' where both sides support '*' (any characters) and '?' (single character) wildcards: '*/latest' (default) lists the latest version of every file, '*/*' lists all versions of all files, 'name/*' lists all versions of a file, and patterns like 'My*/latest' or 'log??/*' are supported. 'version' also accepts the keyword 'latest'.",
+            Route = "ListFiles",
+            Parameters = new List<FunctionParameterDefinition>
+            {
+                new()
+                {
+                    Name = "file",
+                    Type = "string",
+                    Description = "Filter as 'name/version'. Both sides support '*' and '?' wildcards; 'version' also accepts 'latest'. Defaults to '*/latest'.",
+                    Required = false,
+                    DefaultValue = "*/latest"
+                }
+            }
+        },
+        new FunctionDefinition
+        {
             Name = "ListPrepulled",
             Description = "Lists images currently configured for pre-pulling on Windows nodes. Admin only.",
             Route = "ListPrepulled",

--- a/fkh-backend/ListDatabasesFunction.cs
+++ b/fkh-backend/ListDatabasesFunction.cs
@@ -1,0 +1,28 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class ListDatabasesFunction : FunctionBase
+{
+    private readonly ILogger<ListDatabasesFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhListDatabases _listDatabases;
+
+    public ListDatabasesFunction(
+        ILogger<ListDatabasesFunction> logger,
+        GitHubAuthService gitHub,
+        FkhListDatabases listDatabases)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _listDatabases = listDatabases;
+    }
+
+    [Function("ListDatabases")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "ListDatabases")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "ListDatabases", _listDatabases.ListDatabasesAsync);
+}

--- a/fkh-backend/ListFilesFunction.cs
+++ b/fkh-backend/ListFilesFunction.cs
@@ -1,0 +1,28 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class ListFilesFunction : FunctionBase
+{
+    private readonly ILogger<ListFilesFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhListFiles _listFiles;
+
+    public ListFilesFunction(
+        ILogger<ListFilesFunction> logger,
+        GitHubAuthService gitHub,
+        FkhListFiles listFiles)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _listFiles = listFiles;
+    }
+
+    [Function("ListFiles")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "ListFiles")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "ListFiles", _listFiles.ListFilesAsync);
+}

--- a/fkh-backend/Program.cs
+++ b/fkh-backend/Program.cs
@@ -38,6 +38,10 @@ var host = new HostBuilder()
         services.AddSingleton<FkhGetDatabaseDownloadSas>();
         services.AddSingleton<FkhGetFileUploadSas>();
         services.AddSingleton<FkhGetFileDownloadSas>();
+        services.AddSingleton<FkhRemoveDatabase>();
+        services.AddSingleton<FkhRemoveFile>();
+        services.AddSingleton<FkhListDatabases>();
+        services.AddSingleton<FkhListFiles>();
         services.AddSingleton<FkhBackupTenantDatabase>();
         services.AddSingleton<FkhRestoreTenantDatabase>();
         services.AddSingleton<FkhDismountTenant>();

--- a/fkh-backend/RemoveDatabaseFunction.cs
+++ b/fkh-backend/RemoveDatabaseFunction.cs
@@ -1,0 +1,28 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class RemoveDatabaseFunction : FunctionBase
+{
+    private readonly ILogger<RemoveDatabaseFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhRemoveDatabase _removeDatabase;
+
+    public RemoveDatabaseFunction(
+        ILogger<RemoveDatabaseFunction> logger,
+        GitHubAuthService gitHub,
+        FkhRemoveDatabase removeDatabase)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _removeDatabase = removeDatabase;
+    }
+
+    [Function("RemoveDatabase")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "RemoveDatabase")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "RemoveDatabase", _removeDatabase.RemoveDatabaseAsync);
+}

--- a/fkh-backend/RemoveFileFunction.cs
+++ b/fkh-backend/RemoveFileFunction.cs
@@ -1,0 +1,28 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class RemoveFileFunction : FunctionBase
+{
+    private readonly ILogger<RemoveFileFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhRemoveFile _removeFile;
+
+    public RemoveFileFunction(
+        ILogger<RemoveFileFunction> logger,
+        GitHubAuthService gitHub,
+        FkhRemoveFile removeFile)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _removeFile = removeFile;
+    }
+
+    [Function("RemoveFile")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "RemoveFile")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "RemoveFile", _removeFile.RemoveFileAsync);
+}

--- a/fkh-backend/Services/FkhListDatabases.cs
+++ b/fkh-backend/Services/FkhListDatabases.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+public class FkhListDatabases : FkhListVersionedBlobBase
+{
+    public FkhListDatabases(ILogger<FkhListDatabases> logger) : base(logger) { }
+
+    public Task<object> ListDatabasesAsync(Dictionary<string, string> parameters)
+        => ListVersionedBlobAsync(
+            containerName: "databases",
+            referenceParameterName: "database",
+            parameters);
+}

--- a/fkh-backend/Services/FkhListFiles.cs
+++ b/fkh-backend/Services/FkhListFiles.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+public class FkhListFiles : FkhListVersionedBlobBase
+{
+    public FkhListFiles(ILogger<FkhListFiles> logger) : base(logger) { }
+
+    public Task<object> ListFilesAsync(Dictionary<string, string> parameters)
+        => ListVersionedBlobAsync(
+            containerName: "files",
+            referenceParameterName: "file",
+            parameters);
+}

--- a/fkh-backend/Services/FkhListVersionedBlobBase.cs
+++ b/fkh-backend/Services/FkhListVersionedBlobBase.cs
@@ -1,0 +1,165 @@
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Fkh.Services;
+
+public abstract class FkhListVersionedBlobBase : FkhServiceBase
+{
+    protected FkhListVersionedBlobBase(ILogger logger) : base(logger) { }
+
+    private const string ManifestSuffix = "/all.json";
+
+    protected async Task<object> ListVersionedBlobAsync(
+        string containerName,
+        string referenceParameterName,
+        Dictionary<string, string> parameters)
+    {
+        var reference = parameters.TryGetValue(referenceParameterName, out var r) && !string.IsNullOrWhiteSpace(r)
+            ? r
+            : "*/latest";
+
+        var parts = reference.Split('/', 2);
+        var namePattern = string.IsNullOrWhiteSpace(parts[0]) ? "*" : parts[0];
+        var versionPattern = parts.Length == 2 && !string.IsNullOrWhiteSpace(parts[1]) ? parts[1] : "latest";
+
+#pragma warning disable CS0618
+        var credential = new ManagedIdentityCredential(ClientId);
+#pragma warning restore CS0618
+        var blobServiceClient = new BlobServiceClient(
+            new Uri($"https://{DbsStorageAccountName}.blob.core.windows.net"), credential);
+        var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+
+        if (!await containerClient.ExistsAsync())
+            return new { Items = Array.Empty<object>() };
+
+        // Resolve the set of names to inspect. A literal name (no wildcard characters)
+        // is fetched directly; otherwise enumerate manifests and filter with a
+        // PowerShell '-like'-style wildcard match.
+        List<string> names;
+        if (IsLiteral(namePattern))
+        {
+            names = new List<string> { namePattern };
+        }
+        else
+        {
+            var nameRegex = WildcardToRegex(namePattern);
+            var prefix = LiteralPrefix(namePattern);
+            names = new List<string>();
+            await foreach (var blob in containerClient.GetBlobsAsync(prefix: prefix))
+            {
+                if (!blob.Name.EndsWith(ManifestSuffix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var name = blob.Name[..^ManifestSuffix.Length];
+                if (name.Contains('/'))
+                    continue;
+                if (nameRegex.IsMatch(name))
+                    names.Add(name);
+            }
+            names.Sort(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var items = new List<object>();
+        foreach (var name in names)
+        {
+            var manifest = await TryDownloadManifestAsync(containerClient, name);
+            if (manifest is null)
+                continue;
+
+            IEnumerable<string> versions;
+            if (string.Equals(versionPattern, "latest", StringComparison.OrdinalIgnoreCase))
+            {
+                // 'latest' is a keyword resolving to the manifest's latest pointer.
+                versions = string.IsNullOrWhiteSpace(manifest.Latest)
+                    ? Enumerable.Empty<string>()
+                    : new[] { manifest.Latest };
+            }
+            else if (IsLiteral(versionPattern))
+            {
+                versions = manifest.Versions.Where(v => string.Equals(v, versionPattern, StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                var versionRegex = WildcardToRegex(versionPattern);
+                versions = manifest.Versions.Where(v => versionRegex.IsMatch(v));
+            }
+
+            foreach (var version in versions)
+            {
+                items.Add(new
+                {
+                    Name = name,
+                    Version = version,
+                    IsLatest = string.Equals(version, manifest.Latest, StringComparison.OrdinalIgnoreCase)
+                });
+            }
+        }
+
+        return new { Items = items };
+    }
+
+    /// <summary>True when the pattern contains no wildcard metacharacters (* ?).</summary>
+    private static bool IsLiteral(string pattern)
+        => pattern.IndexOfAny(new[] { '*', '?' }) < 0;
+
+    /// <summary>Returns the leading literal portion of a wildcard pattern (used as a blob-listing prefix).</summary>
+    private static string LiteralPrefix(string pattern)
+    {
+        var stop = pattern.IndexOfAny(new[] { '*', '?' });
+        return stop < 0 ? pattern : pattern[..stop];
+    }
+
+    /// <summary>
+    /// Converts a wildcard pattern into an anchored, case-insensitive regex.
+    /// Supports only '*' (any run of characters) and '?' (a single character);
+    /// every other character is matched literally.
+    /// </summary>
+    private static Regex WildcardToRegex(string pattern)
+    {
+        var sb = new StringBuilder("^");
+        foreach (var c in pattern)
+        {
+            switch (c)
+            {
+                case '*':
+                    sb.Append(".*");
+                    break;
+                case '?':
+                    sb.Append('.');
+                    break;
+                default:
+                    sb.Append(Regex.Escape(c.ToString()));
+                    break;
+            }
+        }
+        sb.Append('$');
+        return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    private static async Task<VersionedBlobManifest?> TryDownloadManifestAsync(BlobContainerClient containerClient, string name)
+
+    {
+        var manifestClient = containerClient.GetBlobClient($"{name}{ManifestSuffix}");
+        try
+        {
+            var downloadResponse = await manifestClient.DownloadContentAsync();
+            var existingJson = downloadResponse.Value.Content.ToString();
+            return JsonSerializer.Deserialize<VersionedBlobManifest>(existingJson,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? new VersionedBlobManifest();
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    private sealed class VersionedBlobManifest
+    {
+        public List<string> Versions { get; set; } = new();
+        public string? Latest { get; set; }
+    }
+}

--- a/fkh-backend/Services/FkhRemoveDatabase.cs
+++ b/fkh-backend/Services/FkhRemoveDatabase.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+public class FkhRemoveDatabase : FkhRemoveVersionedBlobBase
+{
+    public FkhRemoveDatabase(ILogger<FkhRemoveDatabase> logger) : base(logger) { }
+
+    public Task<object> RemoveDatabaseAsync(Dictionary<string, string> parameters)
+        => RemoveVersionedBlobAsync(
+            containerName: "databases",
+            itemKind: "database",
+            referenceParameterName: "database",
+            getBlobName: static (name, version) => $"{name}/{version}.bak",
+            parameters);
+}

--- a/fkh-backend/Services/FkhRemoveFile.cs
+++ b/fkh-backend/Services/FkhRemoveFile.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+public class FkhRemoveFile : FkhRemoveVersionedBlobBase
+{
+    public FkhRemoveFile(ILogger<FkhRemoveFile> logger) : base(logger) { }
+
+    public Task<object> RemoveFileAsync(Dictionary<string, string> parameters)
+        => RemoveVersionedBlobAsync(
+            containerName: "files",
+            itemKind: "file",
+            referenceParameterName: "file",
+            getBlobName: static (name, version) => $"{name}/{version}",
+            parameters);
+}

--- a/fkh-backend/Services/FkhRemoveVersionedBlobBase.cs
+++ b/fkh-backend/Services/FkhRemoveVersionedBlobBase.cs
@@ -1,0 +1,129 @@
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+using System.Text;
+using System.Text.Json;
+
+namespace Fkh.Services;
+
+public abstract class FkhRemoveVersionedBlobBase : FkhServiceBase
+{
+    protected FkhRemoveVersionedBlobBase(ILogger logger) : base(logger) { }
+
+    protected async Task<object> RemoveVersionedBlobAsync(
+        string containerName,
+        string itemKind,
+        string referenceParameterName,
+        Func<string, string, string> getBlobName,
+        Dictionary<string, string> parameters)
+    {
+        if (!parameters.TryGetValue(referenceParameterName, out var reference) || string.IsNullOrWhiteSpace(reference))
+            throw new ArgumentException($"Missing required parameter '{referenceParameterName}'.");
+
+        var parts = reference.Split('/', 2);
+        var name = parts[0];
+        if (string.IsNullOrWhiteSpace(name) || (parts.Length == 2 && string.IsNullOrWhiteSpace(parts[1])))
+            throw new ArgumentException($"Invalid {referenceParameterName} value '{reference}'. Expected 'name/version' or just 'name' to remove the latest version.");
+        var version = parts.Length == 2 ? parts[1] : "latest";
+
+        var username = parameters.GetValueOrDefault("_githubUsername", "unknown");
+
+#pragma warning disable CS0618
+        var credential = new ManagedIdentityCredential(ClientId);
+#pragma warning restore CS0618
+        var blobServiceClient = new BlobServiceClient(
+            new Uri($"https://{DbsStorageAccountName}.blob.core.windows.net"), credential);
+        var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+
+        var manifestBlobName = $"{name}/all.json";
+        var manifestClient = containerClient.GetBlobClient(manifestBlobName);
+
+        VersionedBlobManifest manifest;
+        try
+        {
+            var downloadResponse = await manifestClient.DownloadContentAsync();
+            var existingJson = downloadResponse.Value.Content.ToString();
+            manifest = JsonSerializer.Deserialize<VersionedBlobManifest>(existingJson,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? new VersionedBlobManifest();
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+        {
+            throw new InvalidOperationException($"No uploaded {itemKind} named '{name}' found (missing {manifestBlobName}).");
+        }
+
+        string resolvedVersion;
+        var removingLatest = string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase);
+        if (removingLatest)
+        {
+            if (string.IsNullOrWhiteSpace(manifest.Latest))
+                throw new InvalidOperationException($"{itemKind} '{name}' manifest has no 'latest' version to remove.");
+            resolvedVersion = manifest.Latest;
+        }
+        else
+        {
+            if (!manifest.Versions.Contains(version, StringComparer.OrdinalIgnoreCase))
+                throw new InvalidOperationException(
+                    $"Version '{version}' not found for {itemKind} '{name}'. Available versions: {string.Join(", ", manifest.Versions)}");
+            resolvedVersion = version;
+        }
+
+        var wasLatest = string.Equals(manifest.Latest, resolvedVersion, StringComparison.OrdinalIgnoreCase);
+
+        Logger.LogInformation(
+            "User '{User}' removing {ItemKind} '{Name}' version '{Version}' from container '{Container}'.",
+            username, itemKind, name, resolvedVersion, containerName);
+
+        // Delete the versioned blob.
+        var blobName = getBlobName(name, resolvedVersion);
+        await containerClient.GetBlobClient(blobName).DeleteIfExistsAsync();
+
+        // Remove the version from the manifest.
+        manifest.Versions.RemoveAll(v => string.Equals(v, resolvedVersion, StringComparison.OrdinalIgnoreCase));
+
+        var manifestDeleted = false;
+        if (manifest.Versions.Count == 0)
+        {
+            // No versions remain; remove the manifest entirely.
+            manifest.Latest = null;
+            await manifestClient.DeleteIfExistsAsync();
+            manifestDeleted = true;
+        }
+        else
+        {
+            if (wasLatest)
+            {
+                // Point 'latest' at the most recently uploaded remaining version (the previous "second latest").
+                manifest.Latest = manifest.Versions[^1];
+            }
+
+            var manifestJson = JsonSerializer.Serialize(manifest, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
+            using var manifestStream = new MemoryStream(Encoding.UTF8.GetBytes(manifestJson));
+            await manifestClient.UploadAsync(manifestStream, overwrite: true);
+        }
+
+        Logger.LogInformation(
+            "Removed {ItemKind} '{Name}' version '{Version}'. Remaining versions: {Count}. New latest: {Latest}.",
+            itemKind, name, resolvedVersion, manifest.Versions.Count, manifest.Latest ?? "(none)");
+
+        return new
+        {
+            Name = name,
+            RemovedVersion = resolvedVersion,
+            BlobName = blobName,
+            Versions = manifest.Versions,
+            Latest = manifest.Latest,
+            ManifestDeleted = manifestDeleted
+        };
+    }
+
+    private sealed class VersionedBlobManifest
+    {
+        public List<string> Versions { get; set; } = new();
+        public string? Latest { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request introduces new Azure Function endpoints and supporting services for listing and removing versioned databases and files stored in blob storage. The core logic for wildcard-based listing and safe removal (with manifest updates) is implemented in new service base classes, and all new endpoints are registered for dependency injection.

**New Function Endpoints:**

- Added endpoints to list and remove versioned databases and files, each with appropriate parameter validation, admin restrictions, and confirmation requirements.
  - `ListDatabasesFunction` and `ListFilesFunction` for listing with wildcard support. [[1]](diffhunk://#diff-3895a626a3a148a2becf846ec4a9bd4d886ae969b84cd5922fb587cf7f3efd46R1-R28) [[2]](diffhunk://#diff-3c3b85627d83dd7ef5233c68ea15b07d2f673d3bfe4af5f2ec1540c80fffde10R1-R28)
  - `RemoveDatabaseFunction` and `RemoveFileFunction` for removing versions and updating manifests. [[1]](diffhunk://#diff-99a93c94096fa4085f460073709d27b11e3992675546c588d1aca2ca95f5763fR1-R28) [[2]](diffhunk://#diff-a37ea145f7f42242c7192e6b4dda856b6b7aa5ffa3a1216fa7c6049e24a6b839R1-R28)

**Service Layer and Logic:**

- Implemented `FkhListVersionedBlobBase` for wildcard pattern matching and manifest-driven listing of databases/files. [[1]](diffhunk://#diff-af653b48f1b35c3322a1b99d6aff53d2fd6a4b25359c49259da81a0845e4a1edR1-R14) [[2]](diffhunk://#diff-36d1f47cb1cb81dbdc18f9f391e154b0a6e398e9be5fbf6df2eae9fd0bba6dc6R1-R14) [[3]](diffhunk://#diff-3d83d991f771b4ae61c07a8f89ce1963f344e9724f2029cc8b9bbc4ad03ad2d8R1-R165)
- Implemented `FkhRemoveVersionedBlobBase` for safe removal of a specific or latest version, updating or deleting the manifest as needed. [[1]](diffhunk://#diff-0d07c7c7c6201ab537a66320543a7c704704f77e30d3e3e0c3847641c1d169ccR1-R16) [[2]](diffhunk://#diff-42640c39057a42e17625d84678310c00558c8147a79a8400ec6c881ddd9f92ddR1-R16) [[3]](diffhunk://#diff-99114b54fb52786718d156fd4db9d3cb59f8e9bd144e5bebe2238e0cb61d6b6bR1-R129)

**Dependency Injection Registration:**

- Registered all new services (`FkhListDatabases`, `FkhListFiles`, `FkhRemoveDatabase`, `FkhRemoveFile`) for DI in `Program.cs`.