### PR TITLE
Fixes issue 30

### DIFF
--- a/fkh-vsix/src/extension.ts
+++ b/fkh-vsix/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { createReadSettingsOptions, readSettings, getRepoName, getProjects } from './readALGoSettings';
 import { ProjectsTreeProvider, ProjectTreeItem, ContainersTreeProvider, ContainerTreeItem, ImagesTreeProvider, ImageTreeItem, VMsTreeProvider, VMTreeItem } from './containersTreeProvider';
-import { updateLaunchJsonAfterCreate } from './updateLaunchJson';
+import { updateLaunchJsonAfterCreate, removeLaunchJsonAfterRemove } from './updateLaunchJson';
 import { PROTOCOL_VERSION, CLIENT_APP } from './protocol';
 
 let functionCatalog: FunctionCatalogResponse | undefined;
@@ -206,6 +206,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('fkh.removeContainer', async (item: ContainerTreeItem | ProjectTreeItem) => {
       if (!item.containerInfo) { return; }
       const name = item.containerInfo.appLabel;
+      const project = item.containerInfo.project;
       const confirm = await vscode.window.showWarningMessage(
         `Are you sure you want to remove '${name}'? This will delete the container and its database.`,
         { modal: true },
@@ -213,6 +214,15 @@ export function activate(context: vscode.ExtensionContext) {
       );
       if (confirm !== 'Remove') { return; }
       await invokeFunctionByName('RemoveContainer', { name });
+      // Clean up the launch configuration for this container. This runs even if
+      // the backend call failed (e.g. the container was already gone), so a
+      // stale configuration doesn't linger. It is skipped only when the user
+      // cancels the confirmation above.
+      try {
+        await removeLaunchJsonAfterRemove(name, project);
+      } catch (err) {
+        logOutput(`[RemoveLaunchJson] ${err instanceof Error ? err.message : String(err)}`, true);
+      }
     }),
     vscode.commands.registerCommand('fkh.waitForContainer', async (item: ContainerTreeItem | ProjectTreeItem) => {
       if (!item.containerInfo) { return; }

--- a/fkh-vsix/src/updateLaunchJson.ts
+++ b/fkh-vsix/src/updateLaunchJson.ts
@@ -34,6 +34,68 @@ export async function updateLaunchJsonAfterCreate(
   }
 }
 
+/**
+ * After a container is removed, remove the matching launch configuration(s)
+ * from launch.json files in app folders.
+ *
+ * The launch configuration created by `updateLaunchJsonAfterCreate` is named
+ * after the container's deployment name (e.g. `myapp-deployment`), while the
+ * container's app label is the base name (e.g. `myapp`). Both variants are
+ * matched to be robust.
+ *
+ * The setting `fkh.CreateContainer.updateLaunchJson` controls the search scope,
+ * mirroring the create behavior.
+ */
+export async function removeLaunchJsonAfterRemove(
+  containerName: string,
+  project?: string,
+): Promise<void> {
+  const mode = vscode.workspace.getConfiguration('fkh').get<string>('CreateContainer.updateLaunchJson', 'project');
+  if (mode === 'none') { return; }
+
+  const repoRoot = getGitRootUri();
+  if (!repoRoot) { return; }
+
+  const searchRoot = mode === 'project' && project && project !== '.'
+    ? vscode.Uri.joinPath(repoRoot, project)
+    : repoRoot;
+
+  const appFolders = await findAppFolders(searchRoot);
+  if (appFolders.length === 0) { return; }
+
+  const names = new Set([containerName, `${containerName}-deployment`]);
+  for (const appFolder of appFolders) {
+    await removeLaunchConfiguration(appFolder, names);
+  }
+}
+
+async function removeLaunchConfiguration(appFolder: vscode.Uri, names: Set<string>): Promise<void> {
+  const launchUri = vscode.Uri.joinPath(appFolder, '.vscode', 'launch.json');
+
+  let launchJson: { version: string; configurations: Record<string, unknown>[] };
+
+  try {
+    const content = await vscode.workspace.fs.readFile(launchUri);
+    const text = new TextDecoder().decode(content);
+    launchJson = JSON.parse(stripJsonComments(text));
+  } catch {
+    // File doesn't exist or is not parseable — nothing to clean up
+    return;
+  }
+
+  if (!Array.isArray(launchJson.configurations)) { return; }
+
+  const filtered = launchJson.configurations.filter(
+    (c) => !(typeof c === 'object' && c !== null && names.has((c as Record<string, unknown>)['name'] as string)),
+  );
+
+  if (filtered.length === launchJson.configurations.length) { return; }
+
+  launchJson.configurations = filtered;
+  const output = JSON.stringify(launchJson, null, 4) + '\n';
+  await vscode.workspace.fs.writeFile(launchUri, new TextEncoder().encode(output));
+}
+
 async function findAppFolders(root: vscode.Uri): Promise<vscode.Uri[]> {
   const result: vscode.Uri[] = [];
   await walkForAppJson(root, result);


### PR DESCRIPTION
Fixes #30

This pull request enhances the container removal workflow by ensuring that any associated launch configurations in `launch.json` are properly cleaned up when a container is deleted. This prevents stale or orphaned launch configurations from lingering in the project, improving the overall developer experience.

**Container removal and launch configuration cleanup:**

* Added a new function `removeLaunchJsonAfterRemove` to `updateLaunchJson.ts` that removes matching launch configurations from `launch.json` files in relevant app folders when a container is deleted. This function matches both the container's base name and its deployment name variant to ensure robust cleanup.
* Updated the `fkh.removeContainer` command in `extension.ts` to invoke `removeLaunchJsonAfterRemove` after attempting to remove a container, ensuring launch configurations are cleaned up even if the backend removal fails or the container was already gone.
* Modified imports in `extension.ts` to include the new `removeLaunchJsonAfterRemove` function.