### PR TITLE
Add clusterschedule to save cost

### DIFF
--- a/.github/workflows/DeployFkhFullStack.yml
+++ b/.github/workflows/DeployFkhFullStack.yml
@@ -122,6 +122,13 @@ jobs:
         shell: pwsh
         run: |
           $varFile = "${{ steps.tfvars.outputs.tfvars_file }}"
+
+          # Fail fast on invalid default_user_settings JSON (otherwise it deploys silently and getsettings returns empty).
+          # Use System.Text.Json to match the backend's parser (ConvertFrom-Json is more lenient, e.g. allows trailing commas).
+          if ((Get-Content $varFile -Raw) -match '(?s)default_user_settings\s*=\s*<<-?\s*(\w+)\r?\n(.*?)\r?\n\s*\1\b') {
+            try { [System.Text.Json.JsonDocument]::Parse($Matches[2]).Dispose() } catch { throw "default_user_settings in config/deployment.tfvars is not valid JSON: $($_.Exception.Message)" }
+          }
+
           function Get-TfVar([string]$Name, [string]$File) {
             $line = Get-Content $File | Where-Object { $_ -match "^\s*$Name\s*=" } | Select-Object -First 1
             if ($line -match '=\s*"([^"]+)"') { return $Matches[1] }

--- a/Installation/Step5-ConfigureEnvironment.md
+++ b/Installation/Step5-ConfigureEnvironment.md
@@ -196,6 +196,38 @@ EOT
 
 This controls default limits, such as how many simultaneous containers a user can have. Adjust the numbers to match your environment.
 
+#### Optional: scheduled cluster uptime
+
+To automatically stop the cluster outside working hours (and start it again) to save cost, add an `Uptime` block under `_admins`:
+
+```hcl
+default_user_settings = <<-EOT
+  {
+    "_members": { "MaxContainers": 3 },
+    "_admins": {
+      "MaxContainers": 10,
+      "Uptime": {
+        "TimeZone": "Central European Standard Time",
+        "Weekdays": {
+          "Mon": "06:00-18:00",
+          "Tue": "06:00-18:00",
+          "Wed": "06:00-18:00",
+          "Thu": "06:00-18:00",
+          "Fri": "06:00-18:00"
+        },
+        "UseNagerHolidays": { "Countries": "DK,DE,DE-BE", "Types": "Public,Bank" }
+      }
+    }
+  }
+EOT
+```
+
+- `Weekdays` — uptime window per day as `HH:mm-HH:mm`; a missing day means the cluster stays off all day.
+- `TimeZone` — a Windows time-zone id; times above are wall-clock in this zone. Defaults to UTC if omitted.
+- `UseNagerHolidays` — a day is excluded (cluster off) only when **every** listed country has a matching holiday, so if anyone is working the cluster stays on. `Types` supports `*` wildcards; subdivision codes like `DE-BE` are supported. Uses the public [Nager.Date](https://date.nager.at) API.
+
+This is the **default** schedule. Admins can override it at runtime with `setsettings --username _admins --property Uptime ...`, and one-off overrides are available via `startfkh --autostop <time>` and `stopfkh --autostart <time>`. Runtime values are preserved across `terraform apply`.
+
 ---
 
 ## 5.2 — Commit deployment.tfvars

--- a/Installation/Step5-ConfigureEnvironment.md
+++ b/Installation/Step5-ConfigureEnvironment.md
@@ -226,7 +226,7 @@ EOT
 - `TimeZone` — a Windows time-zone id; times above are wall-clock in this zone. Defaults to UTC if omitted.
 - `UseNagerHolidays` — a day is excluded (cluster off) only when **every** listed country has a matching holiday, so if anyone is working the cluster stays on. `Types` supports `*` wildcards; subdivision codes like `DE-BE` are supported. Uses the public [Nager.Date](https://date.nager.at) API.
 
-This is the **default** schedule. Admins can override it at runtime with `setsettings --username _admins --property Uptime ...`, and one-off overrides are available via `startfkh --autostop <time>` and `stopfkh --autostart <time>`. Runtime values are preserved across `terraform apply`.
+This is the **default** schedule. Admins can override it at runtime with `setsettings --username _admins --property Uptime ...`, and one-off overrides are available via `startfkh --autostop <time>` and `stopfkh --autostart <time>` (values are clamped to a minimum of 2h from now). Runtime values are preserved across `terraform apply`.
 
 ---
 

--- a/Installation/Step5-ConfigureEnvironment.md
+++ b/Installation/Step5-ConfigureEnvironment.md
@@ -198,7 +198,7 @@ This controls default limits, such as how many simultaneous containers a user ca
 
 #### Optional: scheduled cluster uptime
 
-To automatically stop the cluster outside working hours (and start it again) to save cost, add an `Uptime` block under `_admins`:
+To automatically stop the cluster outside working hours (and start it again) to save cost, add a `Uptime` block under `_admins`:
 
 ```hcl
 default_user_settings = <<-EOT

--- a/Installation/Step5-ConfigureEnvironment.md
+++ b/Installation/Step5-ConfigureEnvironment.md
@@ -222,7 +222,10 @@ default_user_settings = <<-EOT
 EOT
 ```
 
-- `Weekdays` — uptime window per day as `HH:mm-HH:mm`; a missing day means the cluster stays off all day.
+- `Weekdays` — uptime rule per day; a missing day means the cluster stays off all day. Each value is one of:
+  - `HH:mm-HH:mm` — auto-start at the first time, auto-stop at the second.
+  - `HH:mm-` — start-only: auto-start at the time, never auto-stop (requires a manual stop).
+  - `-HH:mm` — stop-only: auto-stop at the time, never auto-start (requires a manual start).
 - `TimeZone` — a Windows time-zone id; times above are wall-clock in this zone. Defaults to UTC if omitted.
 - `UseNagerHolidays` — a day is excluded (cluster off) only when **every** listed country has a matching holiday, so if anyone is working the cluster stays on. `Types` supports `*` wildcards; subdivision codes like `DE-BE` are supported. Uses the public [Nager.Date](https://date.nager.at) API.
 

--- a/deployment-repo/config/deployment.tfvars
+++ b/deployment-repo/config/deployment.tfvars
@@ -211,6 +211,18 @@ github_app_installation_id = "123456789"  # paste your Installation ID here
 #                                                      |___/     
 # Default user settings (deployed to settings/usersettings.json in storage)
 # _members = defaults for all users, _admins = defaults for admin users
+#
+# Optional: auto start/stop the cluster on a schedule to save cost. Add an "Uptime"
+# block under "_admins" (runtime 'setsettings' changes override this default and are
+# preserved across 'terraform apply'):
+#   "_admins": {
+#     "MaxContainers": 10,
+#     "Uptime": {
+#       "TimeZone": "Central European Standard Time",
+#       "Weekdays": { "Mon": "06:00-18:00", "Tue": "06:00-18:00", "Wed": "06:00-18:00", "Thu": "06:00-18:00", "Fri": "06:00-18:00" },
+#       "UseNagerHolidays": { "Countries": "DK", "Types": "Public,Bank" }
+#     }
+#   }
 default_user_settings = <<-EOT
   {
     "_members": {

--- a/deployment-repo/config/deployment.tfvars
+++ b/deployment-repo/config/deployment.tfvars
@@ -223,6 +223,10 @@ github_app_installation_id = "123456789"  # paste your Installation ID here
 #       "UseNagerHolidays": { "Countries": "DK", "Types": "Public,Bank" }
 #     }
 #   }
+# Each weekday value is one of:
+#   "HH:mm-HH:mm" - auto-start at the first time, auto-stop at the second.
+#   "HH:mm-"      - start-only: auto-start at the time, never auto-stop (manual stop).
+#   "-HH:mm"      - stop-only: auto-stop at the time, never auto-start (manual start).
 default_user_settings = <<-EOT
   {
     "_members": {

--- a/deployment-repo/config/deployment.tfvars
+++ b/deployment-repo/config/deployment.tfvars
@@ -220,7 +220,7 @@ github_app_installation_id = "123456789"  # paste your Installation ID here
 #     "MaxContainers": 10,
 #     "Uptime": {
 #       "TimeZone": "Central European Standard Time",
-#       "Weekdays": { "Mon": "06:00-18:00", "Tue": "06:00-18:00", "Wed": "06:00-18:00", "Thu": "06:00-18:00", "Fri": "06:00-18:00" },
+#       "Weekdays": { "Mon": "06:00-18:00", "Tue": "06:00-18:00", "Wed": "06:00-18:00", "Thu": "06:00-18:00", "Fri": "06:00-18:00", "Sat": "-18:00", "Sun": "-18:00" },
 #       "UseNagerHolidays": { "Countries": "DK", "Types": "Public,Bank" }
 #     }
 #   }

--- a/deployment-repo/config/deployment.tfvars
+++ b/deployment-repo/config/deployment.tfvars
@@ -212,7 +212,7 @@ github_app_installation_id = "123456789"  # paste your Installation ID here
 # Default user settings (deployed to settings/usersettings.json in storage)
 # _members = defaults for all users, _admins = defaults for admin users
 #
-# Optional: auto start/stop the cluster on a schedule to save cost. Add an "Uptime"
+# Optional: auto start/stop the cluster on a schedule to save cost. Add a "Uptime"
 # block under "_admins" (runtime 'setsettings' changes override this default and are
 # preserved across 'terraform apply'):
 #   "_admins": {

--- a/fkh-backend/AutoStopFunction.cs
+++ b/fkh-backend/AutoStopFunction.cs
@@ -9,12 +9,14 @@ public class AutoStopFunction
     private readonly ILogger<AutoStopFunction> _logger;
     private readonly FkhAutoStop _autoStop;
     private readonly FkhAllowSqlAccess _sqlAccess;
+    private readonly FkhClusterSchedule _clusterSchedule;
 
-    public AutoStopFunction(ILogger<AutoStopFunction> logger, FkhAutoStop autoStop, FkhAllowSqlAccess sqlAccess)
+    public AutoStopFunction(ILogger<AutoStopFunction> logger, FkhAutoStop autoStop, FkhAllowSqlAccess sqlAccess, FkhClusterSchedule clusterSchedule)
     {
         _logger = logger;
         _autoStop = autoStop;
         _sqlAccess = sqlAccess;
+        _clusterSchedule = clusterSchedule;
     }
 
     [Function("AutoStop")]
@@ -36,6 +38,15 @@ public class AutoStopFunction
         catch (Exception ex)
         {
             _logger.LogError(ex, "SQL access auto-revoke check failed.");
+        }
+
+        try
+        {
+            await _clusterSchedule.CheckAndApplyScheduleAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Cluster schedule check failed.");
         }
     }
 }

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -868,11 +868,7 @@ public static class FunctionCatalog
                 },
                 new()
                 {
-                    Name = "autostart",
-                    Type = "string",
-                    Description = "When to automatically start the cluster again, overriding the next scheduled start. Use '<n>h' for hours from now (e.g. '8h') or a time of day (e.g. '06:00'). Leave empty to follow the schedule.",
-                    Required = false,
-                    DefaultValue = null
+                    Description = "When to automatically start the cluster again, overriding the next scheduled start. Use '<n>h' for hours from now (e.g. '8h') or a time of day (e.g. '06:00'). Omit to follow the schedule. Note: times are clamped to a minimum of 2h from now.",
                 }
             }
         },

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -865,6 +865,14 @@ public static class FunctionCatalog
                     Description = "Confirm that you want to stop the cluster.",
                     Required = false,
                     DefaultValue = null
+                },
+                new()
+                {
+                    Name = "autostart",
+                    Type = "string",
+                    Description = "When to automatically start the cluster again, overriding the next scheduled start. Use '<n>h' for hours from now (e.g. '8h') or a time of day (e.g. '06:00'). Leave empty to follow the schedule.",
+                    Required = false,
+                    DefaultValue = null
                 }
             }
         },
@@ -874,7 +882,17 @@ public static class FunctionCatalog
             Description = "Starts a previously stopped AKS cluster. Restores all nodes and workloads. Admin only.",
             Route = "StartFkh",
             AdminOnly = true,
-            Parameters = new List<FunctionParameterDefinition>()
+            Parameters = new List<FunctionParameterDefinition>
+            {
+                new()
+                {
+                    Name = "autostop",
+                    Type = "string",
+                    Description = "When to automatically stop the cluster again, overriding the next scheduled stop. Use '<n>h' for hours from now (e.g. '4h') or a time of day (e.g. '18:00'). Leave empty to follow the schedule.",
+                    Required = false,
+                    DefaultValue = null
+                }
+            }
         },
         new FunctionDefinition
         {

--- a/fkh-backend/Models/ClusterSchedule.cs
+++ b/fkh-backend/Models/ClusterSchedule.cs
@@ -5,7 +5,12 @@ public sealed class UptimeConfig
 {
     public string? TimeZone { get; set; }
 
-    /// <summary>Per-weekday uptime window as "HH:mm-HH:mm" (keys: Mon..Sun). A missing day is off.</summary>
+    /// <summary>
+    /// Per-weekday uptime rule (keys: Mon..Sun; a missing day is off). Supported formats:
+    ///   "HH:mm-HH:mm" — auto-start at the first time and auto-stop at the second.
+    ///   "HH:mm-"      — start-only: auto-start at the time, never auto-stop (manual stop).
+    ///   "-HH:mm"      — stop-only: auto-stop at the time, never auto-start (manual start).
+    /// </summary>
     public Dictionary<string, string>? Weekdays { get; set; }
 
     public NagerHolidayConfig? UseNagerHolidays { get; set; }
@@ -35,6 +40,11 @@ public sealed class ClusterScheduleOverrides
 {
     public DateTimeOffset? NextStart { get; set; }
     public DateTimeOffset? NextStop { get; set; }
+
+    /// <summary>Most recent recurring start/stop edge already applied. Prevents an edge from
+    /// re-firing, so a manual start/stop is respected until the next scheduled edge.</summary>
+    public DateTimeOffset? LastScheduleStart { get; set; }
+    public DateTimeOffset? LastScheduleStop { get; set; }
 }
 
 /// <summary>Computed view of the cluster schedule for status reporting.</summary>

--- a/fkh-backend/Models/ClusterSchedule.cs
+++ b/fkh-backend/Models/ClusterSchedule.cs
@@ -1,0 +1,52 @@
+namespace Fkh.Models;
+
+/// <summary>Recurring cluster uptime schedule, stored as the '_admins.Uptime' setting.</summary>
+public sealed class UptimeConfig
+{
+    public string? TimeZone { get; set; }
+
+    /// <summary>Per-weekday uptime window as "HH:mm-HH:mm" (keys: Mon..Sun). A missing day is off.</summary>
+    public Dictionary<string, string>? Weekdays { get; set; }
+
+    public NagerHolidayConfig? UseNagerHolidays { get; set; }
+}
+
+public sealed class NagerHolidayConfig
+{
+    /// <summary>Comma-separated country/subdivision codes, e.g. "DK,DE,DE-BE".</summary>
+    public string? Countries { get; set; }
+
+    /// <summary>Comma-separated holiday-type globs, e.g. "Public,Bank" or "*".</summary>
+    public string? Types { get; set; }
+}
+
+/// <summary>A single holiday entry from the Nager.Date API.</summary>
+public sealed class NagerHoliday
+{
+    public string Date { get; set; } = "";
+    public bool Global { get; set; }
+    public List<string>? Counties { get; set; }
+    public List<string>? Types { get; set; }
+    public string? CountryCode { get; set; }
+}
+
+/// <summary>One-off cluster start/stop overrides, stored in the 'clusterschedule.json' blob.</summary>
+public sealed class ClusterScheduleOverrides
+{
+    public DateTimeOffset? NextStart { get; set; }
+    public DateTimeOffset? NextStop { get; set; }
+}
+
+/// <summary>Computed view of the cluster schedule for status reporting.</summary>
+public sealed class ScheduleSummary
+{
+    public bool Enabled { get; set; }
+    public string? TimeZone { get; set; }
+    public bool DesiredRunning { get; set; }
+    public bool TodayExcluded { get; set; }
+    public string? TodayWindow { get; set; }
+    public DateTimeOffset? NextStart { get; set; }
+    public DateTimeOffset? NextStop { get; set; }
+    public DateTimeOffset? OverrideStart { get; set; }
+    public DateTimeOffset? OverrideStop { get; set; }
+}

--- a/fkh-backend/Program.cs
+++ b/fkh-backend/Program.cs
@@ -52,6 +52,8 @@ var host = new HostBuilder()
         services.AddSingleton<FkhPrepull>();
         services.AddSingleton<FkhUserSettings>();
         services.AddSingleton<FkhClusterControl>();
+        services.AddSingleton<FkhHolidayService>();
+        services.AddSingleton<FkhClusterSchedule>();
         services.AddSingleton<FkhGetVersion>();
         services.AddSingleton<FkhCopyFileFromContainer>();
         services.AddSingleton<FkhCopyFileToContainer>();

--- a/fkh-backend/Services/FkhClusterControl.cs
+++ b/fkh-backend/Services/FkhClusterControl.cs
@@ -1,12 +1,18 @@
+using System.Text.Json;
 using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.ContainerService;
+using Azure.Storage.Blobs;
+using Fkh.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Fkh.Services;
 
 public class FkhClusterControl : FkhServiceBase
 {
+    private const string SettingsContainer = "settings";
+    private const string OverridesBlob = "clusterschedule.json";
+
     private readonly FkhScaleContainer _scaleContainer;
 
     public FkhClusterControl(ILogger<FkhClusterControl> logger, FkhScaleContainer scaleContainer) : base(logger)
@@ -22,12 +28,26 @@ public class FkhClusterControl : FkhServiceBase
             throw new InvalidOperationException("This will stop the entire AKS cluster and all containers. Pass --confirm to proceed.");
         }
 
+        // Optional one-off override: when the cluster should automatically start again.
+        parameters.TryGetValue("autostart", out var autoStartValue);
+        parameters.TryGetValue("_timezone", out var tz);
+        var autoStart = ParseAutoStop(autoStartValue, tz);
+        var overrides = await GetOverridesAsync();
+        if (autoStart is not null)
+        {
+            overrides.NextStart = autoStart.Value.StopAt;
+            overrides.NextStop = null;
+            await SaveOverridesAsync(overrides);
+        }
+
         var cluster = GetClusterResource();
         var data = (await cluster.GetAsync()).Value.Data;
         var powerState = data.PowerStateCode?.ToString();
 
+        var autoStartText = overrides.NextStart is { } ns ? $"{ns:yyyy-MM-dd HH:mm} UTC" : null;
+
         if (string.Equals(powerState, "Stopped", StringComparison.OrdinalIgnoreCase))
-            return new { Message = "Cluster is already stopped.", PowerState = "Stopped" };
+            return new { Message = "Cluster is already stopped.", PowerState = "Stopped", AutoStart = autoStartText };
 
         // Stop all containers before shutting down the cluster
         try
@@ -44,23 +64,105 @@ public class FkhClusterControl : FkhServiceBase
         await cluster.StopAsync(Azure.WaitUntil.Started);
         Logger.LogInformation("AKS cluster {Cluster} stop initiated.", ClusterName);
 
-        return new { Message = "Cluster stop initiated. It may take a few minutes to fully stop.", PowerState = "Stopping" };
+        return new { Message = "Cluster stop initiated. It may take a few minutes to fully stop.", PowerState = "Stopping", AutoStart = autoStartText };
     }
 
     public async Task<object> StartClusterAsync(Dictionary<string, string> parameters)
     {
+        // Optional one-off override: when the cluster should automatically stop again.
+        parameters.TryGetValue("autostop", out var autoStopValue);
+        parameters.TryGetValue("_timezone", out var tz);
+        var autoStop = ParseAutoStop(autoStopValue, tz);
+        var overrides = await GetOverridesAsync();
+        if (autoStop is not null)
+        {
+            overrides.NextStop = autoStop.Value.StopAt;
+            overrides.NextStart = null;
+            await SaveOverridesAsync(overrides);
+        }
+
         var cluster = GetClusterResource();
         var data = (await cluster.GetAsync()).Value.Data;
         var powerState = data.PowerStateCode?.ToString();
 
+        var autoStopText = overrides.NextStop is { } ns ? $"{ns:yyyy-MM-dd HH:mm} UTC" : null;
+
         if (string.Equals(powerState, "Running", StringComparison.OrdinalIgnoreCase))
-            return new { Message = "Cluster is already running.", PowerState = "Running" };
+            return new { Message = "Cluster is already running.", PowerState = "Running", AutoStop = autoStopText };
 
         Logger.LogInformation("Starting AKS cluster {Cluster} in resource group {RG}...", ClusterName, ResourceGroup);
         await cluster.StartAsync(Azure.WaitUntil.Started);
         Logger.LogInformation("AKS cluster {Cluster} start initiated.", ClusterName);
 
-        return new { Message = "Cluster start initiated. It may take a few minutes before the cluster is fully running.", PowerState = "Starting" };
+        return new { Message = "Cluster start initiated. It may take a few minutes before the cluster is fully running.", PowerState = "Starting", AutoStop = autoStopText };
+    }
+
+    // ── Schedule primitives (used by the auto-schedule timer) ────────────────────
+
+    public async Task<string?> GetPowerStateAsync()
+    {
+        var data = (await GetClusterResource().GetAsync()).Value.Data;
+        return data.PowerStateCode?.ToString();
+    }
+
+    public async Task StartClusterForScheduleAsync()
+    {
+        Logger.LogInformation("Schedule: starting AKS cluster {Cluster}...", ClusterName);
+        await GetClusterResource().StartAsync(Azure.WaitUntil.Started);
+    }
+
+    public async Task StopClusterForScheduleAsync()
+    {
+        try
+        {
+            await _scaleContainer.StopAllContainersAsync(new Dictionary<string, string>());
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Schedule: failed to stop containers before cluster shutdown. Proceeding.");
+        }
+
+        Logger.LogInformation("Schedule: stopping AKS cluster {Cluster}...", ClusterName);
+        await GetClusterResource().StopAsync(Azure.WaitUntil.Started);
+    }
+
+    // ── One-off override persistence (settings-container blob) ──────────────────
+
+    public async Task<ClusterScheduleOverrides> GetOverridesAsync()
+    {
+        var blobClient = GetOverridesBlobClient();
+        if (!await blobClient.ExistsAsync())
+            return new ClusterScheduleOverrides();
+
+        try
+        {
+            var content = (await blobClient.DownloadContentAsync()).Value.Content.ToString();
+            return JsonSerializer.Deserialize<ClusterScheduleOverrides>(content, JsonSerializerOptions.Web)
+                ?? new ClusterScheduleOverrides();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to parse cluster-schedule overrides blob. Ignoring.");
+            return new ClusterScheduleOverrides();
+        }
+    }
+
+    public async Task SaveOverridesAsync(ClusterScheduleOverrides overrides)
+    {
+        var blobClient = GetOverridesBlobClient();
+        var json = JsonSerializer.Serialize(overrides, JsonSerializerOptions.Web);
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        await blobClient.UploadAsync(stream, overwrite: true);
+    }
+
+    private BlobClient GetOverridesBlobClient()
+    {
+#pragma warning disable CS0618
+        var credential = new ManagedIdentityCredential(ClientId);
+#pragma warning restore CS0618
+        var blobServiceClient = new BlobServiceClient(
+            new Uri($"https://{DbsStorageAccountName}.blob.core.windows.net"), credential);
+        return blobServiceClient.GetBlobContainerClient(SettingsContainer).GetBlobClient(OverridesBlob);
     }
 
     private ContainerServiceManagedClusterResource GetClusterResource()

--- a/fkh-backend/Services/FkhClusterSchedule.cs
+++ b/fkh-backend/Services/FkhClusterSchedule.cs
@@ -218,12 +218,18 @@ public class FkhClusterSchedule
     private async Task<DayWindow?> GetWindowAsync(
         UptimeConfig cfg, TimeZoneInfo tz, DateOnly localDate)
     {
-        if (await IsExcludedAsync(cfg, localDate))
-            return null;
+        // Missing/empty day or excluded holiday => cluster should be OFF all day. Model this as an
+        // implicit stop edge at local midnight so the edge-triggered logic can shut down.
+        static DateTimeOffset ToMidnightUtc(DateOnly d, TimeZoneInfo zone) =>
+            new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(d.ToDateTime(TimeOnly.MinValue), zone), TimeSpan.Zero);
 
-        if (cfg.Weekdays is null || !cfg.Weekdays.TryGetValue(DayKeys[(int)localDate.DayOfWeek], out var range)
+        if (await IsExcludedAsync(cfg, localDate))
+            return new DayWindow(null, ToMidnightUtc(localDate, tz));
+
+        if (cfg.Weekdays is null
+            || !cfg.Weekdays.TryGetValue(DayKeys[(int)localDate.DayOfWeek], out var range)
             || string.IsNullOrWhiteSpace(range))
-            return null;
+            return new DayWindow(null, ToMidnightUtc(localDate, tz));
 
         if (!TryParseRange(range, out var startTime, out var stopTime))
             return null;

--- a/fkh-backend/Services/FkhClusterSchedule.cs
+++ b/fkh-backend/Services/FkhClusterSchedule.cs
@@ -70,24 +70,45 @@ public class FkhClusterSchedule
             return;
         }
 
-        // 2. Recurring schedule (suppressed while a one-off override is still pending).
+        // 2. Recurring schedule — edge-triggered. Each start/stop time fires once; a manual
+        //    start/stop is then respected until the next scheduled edge. This also lets a rule
+        //    be one-directional (start-only never auto-stops, stop-only never auto-starts).
         var cfg = await GetUptimeConfigAsync();
         if (cfg?.Weekdays is null || cfg.Weekdays.Count == 0)
             return; // scheduler disabled
 
         var tz = ResolveTimeZone(cfg.TimeZone);
-        var desiredRunning = await IsWithinWindowAsync(cfg, tz, nowUtc);
+        var (recentStart, recentStop) = await MostRecentEdgesAsync(cfg, tz, nowUtc);
 
-        if (desiredRunning && stopped && overrides.NextStart is null)
+        // The later of the two past edges decides the current desired state.
+        var startGoverns = recentStart is { } rs && (recentStop is null || rs >= recentStop);
+        var stopGoverns = recentStop is { } rt && (recentStart is null || rt > recentStart);
+        var changed = false;
+
+        if (recentStart is { } startEdge && !(overrides.LastScheduleStart is { } ls && ls >= startEdge))
         {
-            _logger.LogInformation("Schedule: starting cluster (inside uptime window).");
-            await _clusterControl.StartClusterForScheduleAsync();
+            if (startGoverns && stopped && overrides.NextStart is null)
+            {
+                _logger.LogInformation("Schedule: starting cluster (start edge {Edge} UTC).", startEdge);
+                await _clusterControl.StartClusterForScheduleAsync();
+            }
+            overrides.LastScheduleStart = startEdge;
+            changed = true;
         }
-        else if (!desiredRunning && running && overrides.NextStop is null)
+
+        if (recentStop is { } stopEdge && !(overrides.LastScheduleStop is { } lt && lt >= stopEdge))
         {
-            _logger.LogInformation("Schedule: stopping cluster (outside uptime window).");
-            await _clusterControl.StopClusterForScheduleAsync();
+            if (stopGoverns && running && overrides.NextStop is null)
+            {
+                _logger.LogInformation("Schedule: stopping cluster (stop edge {Edge} UTC).", stopEdge);
+                await _clusterControl.StopClusterForScheduleAsync();
+            }
+            overrides.LastScheduleStop = stopEdge;
+            changed = true;
         }
+
+        if (changed)
+            await _clusterControl.SaveOverridesAsync(overrides);
     }
 
     /// <summary>Builds a read-only summary of the schedule for status reporting.</summary>
@@ -114,7 +135,7 @@ public class FkhClusterSchedule
             ? null
             : (cfg.Weekdays.TryGetValue(DayKeys[(int)localToday.DayOfWeek], out var w) ? w : null);
 
-        summary.DesiredRunning = await IsWithinWindowAsync(cfg, tz, nowUtc);
+        summary.DesiredRunning = summary.TodayExcluded ? false : await ComputeDesiredRunningAsync(cfg, tz, nowUtc);
         (summary.NextStart, summary.NextStop) = await ComputeNextTransitionsAsync(cfg, tz, nowUtc);
         return summary;
     }
@@ -135,11 +156,39 @@ public class FkhClusterSchedule
         }
     }
 
-    private async Task<bool> IsWithinWindowAsync(UptimeConfig cfg, TimeZoneInfo tz, DateTimeOffset instantUtc)
+    /// <summary>A single day's schedule edges (either may be absent for a one-directional rule).</summary>
+    private readonly record struct DayWindow(DateTimeOffset? Start, DateTimeOffset? Stop);
+
+    /// <summary>Desired running state = the later of the two most recent past edges was a start.</summary>
+    private async Task<bool> ComputeDesiredRunningAsync(UptimeConfig cfg, TimeZoneInfo tz, DateTimeOffset nowUtc)
     {
-        var local = TimeZoneInfo.ConvertTime(instantUtc, tz).DateTime;
-        var window = await GetWindowAsync(cfg, tz, DateOnly.FromDateTime(local));
-        return window is { } w && instantUtc >= w.Start && instantUtc < w.Stop;
+        var (recentStart, recentStop) = await MostRecentEdgesAsync(cfg, tz, nowUtc);
+        return recentStart is { } rs && (recentStop is null || rs >= recentStop);
+    }
+
+    /// <summary>Finds the most recent past start edge and stop edge (each searched independently).</summary>
+    private async Task<(DateTimeOffset? Start, DateTimeOffset? Stop)> MostRecentEdgesAsync(
+        UptimeConfig cfg, TimeZoneInfo tz, DateTimeOffset nowUtc)
+    {
+        DateTimeOffset? start = null, stop = null;
+        var localToday = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(nowUtc, tz).DateTime);
+
+        for (var offset = 0; offset <= ScanDays; offset++)
+        {
+            var window = await GetWindowAsync(cfg, tz, localToday.AddDays(-offset));
+            if (window is not { } w)
+                continue;
+
+            if (start is null && w.Start is { } s && s <= nowUtc)
+                start = s;
+            if (stop is null && w.Stop is { } t && t <= nowUtc)
+                stop = t;
+
+            if (start is not null && stop is not null)
+                break;
+        }
+
+        return (start, stop);
     }
 
     private async Task<(DateTimeOffset? NextStart, DateTimeOffset? NextStop)> ComputeNextTransitionsAsync(
@@ -154,10 +203,10 @@ public class FkhClusterSchedule
             if (window is not { } w)
                 continue;
 
-            if (nextStart is null && w.Start > nowUtc)
-                nextStart = w.Start;
-            if (nextStop is null && w.Stop > nowUtc)
-                nextStop = w.Stop;
+            if (nextStart is null && w.Start is { } s && s > nowUtc)
+                nextStart = s;
+            if (nextStop is null && w.Stop is { } t && t > nowUtc)
+                nextStop = t;
 
             if (nextStart is not null && nextStop is not null)
                 break;
@@ -166,7 +215,7 @@ public class FkhClusterSchedule
         return (nextStart, nextStop);
     }
 
-    private async Task<(DateTimeOffset Start, DateTimeOffset Stop)?> GetWindowAsync(
+    private async Task<DayWindow?> GetWindowAsync(
         UptimeConfig cfg, TimeZoneInfo tz, DateOnly localDate)
     {
         if (await IsExcludedAsync(cfg, localDate))
@@ -179,11 +228,13 @@ public class FkhClusterSchedule
         if (!TryParseRange(range, out var startTime, out var stopTime))
             return null;
 
-        var localStart = localDate.ToDateTime(startTime);
-        var localStop = localDate.ToDateTime(stopTime);
-        var start = new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(localStart, tz), TimeSpan.Zero);
-        var stop = new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(localStop, tz), TimeSpan.Zero);
-        return (start, stop);
+        DateTimeOffset? start = startTime is { } st
+            ? new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(localDate.ToDateTime(st), tz), TimeSpan.Zero)
+            : null;
+        DateTimeOffset? stop = stopTime is { } sp
+            ? new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(localDate.ToDateTime(sp), tz), TimeSpan.Zero)
+            : null;
+        return new DayWindow(start, stop);
     }
 
     private Task<bool> IsExcludedAsync(UptimeConfig cfg, DateOnly localDate)
@@ -194,17 +245,32 @@ public class FkhClusterSchedule
         return _holidays.IsExcludedAsync(localDate, holidays.Countries, holidays.Types);
     }
 
-    private static bool TryParseRange(string range, out TimeOnly start, out TimeOnly stop)
+    private static bool TryParseRange(string range, out TimeOnly? start, out TimeOnly? stop)
     {
-        start = default;
-        stop = default;
+        start = null;
+        stop = null;
         var parts = range.Split('-', StringSplitOptions.TrimEntries);
         if (parts.Length != 2)
             return false;
-        if (!TimeOnly.TryParse(parts[0], CultureInfo.InvariantCulture, out start)
-            || !TimeOnly.TryParse(parts[1], CultureInfo.InvariantCulture, out stop))
-            return false;
-        return stop > start;
+
+        if (parts[0].Length > 0)
+        {
+            if (!TimeOnly.TryParse(parts[0], CultureInfo.InvariantCulture, out var s))
+                return false;
+            start = s;
+        }
+        if (parts[1].Length > 0)
+        {
+            if (!TimeOnly.TryParse(parts[1], CultureInfo.InvariantCulture, out var t))
+                return false;
+            stop = t;
+        }
+
+        if (start is null && stop is null)
+            return false; // "-" / empty is not a valid rule
+        if (start is { } sv && stop is { } tv && tv <= sv)
+            return false; // a full window must stop after it starts
+        return true;
     }
 
     private TimeZoneInfo ResolveTimeZone(string? timeZoneId)

--- a/fkh-backend/Services/FkhClusterSchedule.cs
+++ b/fkh-backend/Services/FkhClusterSchedule.cs
@@ -1,0 +1,227 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Fkh.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+/// <summary>
+/// Drives automatic AKS cluster start/stop based on the '_admins.Uptime' schedule,
+/// holiday exclusions, and one-off overrides. Invoked every minute by the timer.
+/// </summary>
+public class FkhClusterSchedule
+{
+    private static readonly string[] DayKeys = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+    private const int ScanDays = 14;
+
+    private readonly ILogger<FkhClusterSchedule> _logger;
+    private readonly FkhClusterControl _clusterControl;
+    private readonly FkhUserSettings _settings;
+    private readonly FkhHolidayService _holidays;
+
+    public FkhClusterSchedule(
+        ILogger<FkhClusterSchedule> logger,
+        FkhClusterControl clusterControl,
+        FkhUserSettings settings,
+        FkhHolidayService holidays)
+    {
+        _logger = logger;
+        _clusterControl = clusterControl;
+        _settings = settings;
+        _holidays = holidays;
+    }
+
+    public async Task CheckAndApplyScheduleAsync()
+    {
+        var nowUtc = DateTimeOffset.UtcNow;
+
+        var powerState = await _clusterControl.GetPowerStateAsync();
+        // Only act on stable states — never interrupt an in-progress start/stop.
+        var running = string.Equals(powerState, "Running", StringComparison.OrdinalIgnoreCase);
+        var stopped = string.Equals(powerState, "Stopped", StringComparison.OrdinalIgnoreCase);
+        if (!running && !stopped)
+            return;
+
+        var overrides = await _clusterControl.GetOverridesAsync();
+
+        // 1. Pending overrides fire first.
+        if (overrides.NextStop is { } nextStop && nowUtc >= nextStop)
+        {
+            if (running)
+            {
+                _logger.LogInformation("Schedule: firing one-off stop (scheduled {StopAt} UTC).", nextStop);
+                await _clusterControl.StopClusterForScheduleAsync();
+            }
+            overrides.NextStop = null;
+            await _clusterControl.SaveOverridesAsync(overrides);
+            return;
+        }
+
+        if (overrides.NextStart is { } nextStart && nowUtc >= nextStart)
+        {
+            if (stopped)
+            {
+                _logger.LogInformation("Schedule: firing one-off start (scheduled {StartAt} UTC).", nextStart);
+                await _clusterControl.StartClusterForScheduleAsync();
+            }
+            overrides.NextStart = null;
+            await _clusterControl.SaveOverridesAsync(overrides);
+            return;
+        }
+
+        // 2. Recurring schedule (suppressed while a one-off override is still pending).
+        var cfg = await GetUptimeConfigAsync();
+        if (cfg?.Weekdays is null || cfg.Weekdays.Count == 0)
+            return; // scheduler disabled
+
+        var tz = ResolveTimeZone(cfg.TimeZone);
+        var desiredRunning = await IsWithinWindowAsync(cfg, tz, nowUtc);
+
+        if (desiredRunning && stopped && overrides.NextStart is null)
+        {
+            _logger.LogInformation("Schedule: starting cluster (inside uptime window).");
+            await _clusterControl.StartClusterForScheduleAsync();
+        }
+        else if (!desiredRunning && running && overrides.NextStop is null)
+        {
+            _logger.LogInformation("Schedule: stopping cluster (outside uptime window).");
+            await _clusterControl.StopClusterForScheduleAsync();
+        }
+    }
+
+    /// <summary>Builds a read-only summary of the schedule for status reporting.</summary>
+    public async Task<ScheduleSummary> GetSummaryAsync(DateTimeOffset nowUtc)
+    {
+        var overrides = await _clusterControl.GetOverridesAsync();
+        var summary = new ScheduleSummary
+        {
+            OverrideStart = overrides.NextStart,
+            OverrideStop = overrides.NextStop,
+        };
+
+        var cfg = await GetUptimeConfigAsync();
+        if (cfg?.Weekdays is null || cfg.Weekdays.Count == 0)
+            return summary;
+
+        summary.Enabled = true;
+        var tz = ResolveTimeZone(cfg.TimeZone);
+        summary.TimeZone = tz.Id;
+
+        var localToday = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(nowUtc, tz).DateTime);
+        summary.TodayExcluded = await IsExcludedAsync(cfg, localToday);
+        summary.TodayWindow = summary.TodayExcluded
+            ? null
+            : (cfg.Weekdays.TryGetValue(DayKeys[(int)localToday.DayOfWeek], out var w) ? w : null);
+
+        summary.DesiredRunning = await IsWithinWindowAsync(cfg, tz, nowUtc);
+        (summary.NextStart, summary.NextStop) = await ComputeNextTransitionsAsync(cfg, tz, nowUtc);
+        return summary;
+    }
+
+    private async Task<UptimeConfig?> GetUptimeConfigAsync()
+    {
+        var node = await _settings.GetGlobalSettingAsync("Uptime");
+        if (node is null)
+            return null;
+        try
+        {
+            return node.Deserialize<UptimeConfig>(JsonSerializerOptions.Web);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse '_admins.Uptime' setting. Scheduler disabled.");
+            return null;
+        }
+    }
+
+    private async Task<bool> IsWithinWindowAsync(UptimeConfig cfg, TimeZoneInfo tz, DateTimeOffset instantUtc)
+    {
+        var local = TimeZoneInfo.ConvertTime(instantUtc, tz).DateTime;
+        var window = await GetWindowAsync(cfg, tz, DateOnly.FromDateTime(local));
+        return window is { } w && instantUtc >= w.Start && instantUtc < w.Stop;
+    }
+
+    private async Task<(DateTimeOffset? NextStart, DateTimeOffset? NextStop)> ComputeNextTransitionsAsync(
+        UptimeConfig cfg, TimeZoneInfo tz, DateTimeOffset nowUtc)
+    {
+        DateTimeOffset? nextStart = null, nextStop = null;
+        var localToday = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(nowUtc, tz).DateTime);
+
+        for (var offset = 0; offset <= ScanDays; offset++)
+        {
+            var window = await GetWindowAsync(cfg, tz, localToday.AddDays(offset));
+            if (window is not { } w)
+                continue;
+
+            if (nextStart is null && w.Start > nowUtc)
+                nextStart = w.Start;
+            if (nextStop is null && w.Stop > nowUtc)
+                nextStop = w.Stop;
+
+            if (nextStart is not null && nextStop is not null)
+                break;
+        }
+
+        return (nextStart, nextStop);
+    }
+
+    private async Task<(DateTimeOffset Start, DateTimeOffset Stop)?> GetWindowAsync(
+        UptimeConfig cfg, TimeZoneInfo tz, DateOnly localDate)
+    {
+        if (await IsExcludedAsync(cfg, localDate))
+            return null;
+
+        if (cfg.Weekdays is null || !cfg.Weekdays.TryGetValue(DayKeys[(int)localDate.DayOfWeek], out var range)
+            || string.IsNullOrWhiteSpace(range))
+            return null;
+
+        if (!TryParseRange(range, out var startTime, out var stopTime))
+            return null;
+
+        var localStart = localDate.ToDateTime(startTime);
+        var localStop = localDate.ToDateTime(stopTime);
+        var start = new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(localStart, tz), TimeSpan.Zero);
+        var stop = new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(localStop, tz), TimeSpan.Zero);
+        return (start, stop);
+    }
+
+    private Task<bool> IsExcludedAsync(UptimeConfig cfg, DateOnly localDate)
+    {
+        var holidays = cfg.UseNagerHolidays;
+        if (holidays is null || string.IsNullOrWhiteSpace(holidays.Countries))
+            return Task.FromResult(false);
+        return _holidays.IsExcludedAsync(localDate, holidays.Countries, holidays.Types);
+    }
+
+    private static bool TryParseRange(string range, out TimeOnly start, out TimeOnly stop)
+    {
+        start = default;
+        stop = default;
+        var parts = range.Split('-', StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+            return false;
+        if (!TimeOnly.TryParse(parts[0], CultureInfo.InvariantCulture, out start)
+            || !TimeOnly.TryParse(parts[1], CultureInfo.InvariantCulture, out stop))
+            return false;
+        return stop > start;
+    }
+
+    private TimeZoneInfo ResolveTimeZone(string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            _logger.LogWarning("Uptime schedule has no TimeZone set; defaulting to UTC.");
+            return TimeZoneInfo.Utc;
+        }
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            _logger.LogWarning("Unknown TimeZone '{TimeZone}' in Uptime schedule; defaulting to UTC.", timeZoneId);
+            return TimeZoneInfo.Utc;
+        }
+    }
+}

--- a/fkh-backend/Services/FkhHolidayService.cs
+++ b/fkh-backend/Services/FkhHolidayService.cs
@@ -1,0 +1,115 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Fkh.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+/// <summary>
+/// Evaluates public/bank holidays via the Nager.Date API to decide whether a given
+/// date should be excluded from the cluster uptime schedule.
+/// </summary>
+public class FkhHolidayService
+{
+    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(10) };
+    private readonly ILogger<FkhHolidayService> _logger;
+
+    // Cached per (countryCode:year). Failed fetches are evicted so they are retried.
+    private readonly ConcurrentDictionary<string, Task<List<NagerHoliday>?>> _cache = new();
+
+    public FkhHolidayService(ILogger<FkhHolidayService> logger) => _logger = logger;
+
+    /// <summary>
+    /// A date is excluded only when EVERY listed country/subdivision has a matching holiday
+    /// on that date. If any country is a working day — or the API is unreachable — the date
+    /// is not excluded (fail ON).
+    /// </summary>
+    public async Task<bool> IsExcludedAsync(DateOnly date, string? countries, string? types)
+    {
+        if (string.IsNullOrWhiteSpace(countries))
+            return false;
+
+        var tokens = countries.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length == 0)
+            return false;
+
+        var typeGlobs = (string.IsNullOrWhiteSpace(types) ? "*" : types)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (typeGlobs.Length == 0)
+            typeGlobs = new[] { "*" };
+
+        var iso = date.ToString("yyyy-MM-dd");
+
+        foreach (var token in tokens)
+        {
+            var dash = token.IndexOf('-');
+            var countryCode = dash > 0 ? token[..dash] : token;
+            var subdivision = dash > 0 ? token : null;
+
+            var holidays = await GetHolidaysAsync(countryCode, date.Year);
+            if (holidays is null)
+                return false; // fail ON: cannot confirm a holiday, so treat as a working day
+
+            var match = holidays.Any(h =>
+                string.Equals(h.Date, iso, StringComparison.Ordinal)
+                && TypeMatches(h.Types, typeGlobs)
+                && SubdivisionMatches(h, subdivision));
+
+            if (!match)
+                return false; // someone in this country is working
+        }
+
+        return true;
+    }
+
+    private static bool SubdivisionMatches(NagerHoliday holiday, string? subdivision)
+    {
+        if (subdivision is null)
+            return holiday.Global;
+        return holiday.Global
+            || (holiday.Counties is not null && holiday.Counties.Contains(subdivision, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static bool TypeMatches(List<string>? holidayTypes, string[] globs)
+    {
+        if (holidayTypes is null || holidayTypes.Count == 0)
+            return false;
+        return holidayTypes.Any(t => globs.Any(g => GlobMatch(t, g)));
+    }
+
+    private static bool GlobMatch(string value, string pattern)
+    {
+        if (pattern == "*")
+            return true;
+        if (!pattern.Contains('*'))
+            return string.Equals(value, pattern, StringComparison.OrdinalIgnoreCase);
+        var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+        return Regex.IsMatch(value, regex, RegexOptions.IgnoreCase);
+    }
+
+    private async Task<List<NagerHoliday>?> GetHolidaysAsync(string countryCode, int year)
+    {
+        var key = $"{countryCode.ToUpperInvariant()}:{year}";
+        var task = _cache.GetOrAdd(key, _ => FetchHolidaysAsync(countryCode, year));
+        var result = await task;
+        if (result is null)
+            _cache.TryRemove(new KeyValuePair<string, Task<List<NagerHoliday>?>>(key, task));
+        return result;
+    }
+
+    private async Task<List<NagerHoliday>?> FetchHolidaysAsync(string countryCode, int year)
+    {
+        try
+        {
+            var url = $"https://date.nager.at/api/v3/PublicHolidays/{year}/{countryCode.ToUpperInvariant()}";
+            var json = await _http.GetStringAsync(url);
+            return JsonSerializer.Deserialize<List<NagerHoliday>>(json, JsonSerializerOptions.Web) ?? new();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch Nager holidays for {Country} {Year}. Treating date as a working day.", countryCode, year);
+            return null;
+        }
+    }
+}

--- a/fkh-backend/Services/FkhStatus.cs
+++ b/fkh-backend/Services/FkhStatus.cs
@@ -15,7 +15,12 @@ namespace Fkh.Services;
 
 public class FkhStatus : FkhServiceBase
 {
-    public FkhStatus(ILogger<FkhStatus> logger) : base(logger) { }
+    private readonly FkhClusterSchedule _clusterSchedule;
+
+    public FkhStatus(ILogger<FkhStatus> logger, FkhClusterSchedule clusterSchedule) : base(logger)
+    {
+        _clusterSchedule = clusterSchedule;
+    }
 
     public async Task<object> GetStatusAsync(Dictionary<string, string> parameters)
     {
@@ -50,6 +55,8 @@ public class FkhStatus : FkhServiceBase
             FkhFork = Environment.GetEnvironmentVariable("FKH_FORK"),
         };
 
+        var clusterSchedule = await GetClusterScheduleAsync();
+
         if (!string.Equals(powerState, "Running", StringComparison.OrdinalIgnoreCase))
         {
             return new
@@ -58,6 +65,7 @@ public class FkhStatus : FkhServiceBase
                 ClusterPowerState = powerState ?? "Unknown",
                 BackendUrl = $"https://{Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME")}/api",
                 Version = versionInfo,
+                ClusterSchedule = clusterSchedule,
                 Message = string.Equals(powerState, "Stopped", StringComparison.OrdinalIgnoreCase)
                     ? "The cluster is stopped. Use 'fkh startfkh' to start it."
                     : $"The cluster is currently {powerState?.ToLowerInvariant() ?? "unknown"}. Please wait for it to be fully running.",
@@ -78,11 +86,25 @@ public class FkhStatus : FkhServiceBase
             ClusterPowerState = powerState,
             BackendUrl = $"https://{Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME")}/api",
             Version = versionInfo,
+            ClusterSchedule = clusterSchedule,
             Kubernetes = await kubeTask,
             Storage = await storageTask,
             Quota = await quotaTask,
             Security = await securityTask,
         };
+    }
+
+    private async Task<object?> GetClusterScheduleAsync()
+    {
+        try
+        {
+            return await _clusterSchedule.GetSummaryAsync(DateTimeOffset.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to compute cluster schedule summary for status.");
+            return null;
+        }
     }
 
     private async Task<string?> GetClusterPowerStateAsync(Azure.Core.TokenCredential credential)

--- a/fkh-backend/Services/FkhUserSettings.cs
+++ b/fkh-backend/Services/FkhUserSettings.cs
@@ -20,6 +20,7 @@ public class FkhUserSettings : FkhServiceBase
     private static readonly Dictionary<string, SettingDefinition> KnownSettings = new(StringComparer.OrdinalIgnoreCase)
     {
         ["MaxContainers"] = new SettingDefinition { DefaultValue = JsonValue.Create(3), AdminOnly = true },
+        ["Uptime"] = new SettingDefinition { DefaultValue = null, AdminOnly = true },
     };
 
     public FkhUserSettings(ILogger<FkhUserSettings> logger) : base(logger) { }
@@ -278,6 +279,25 @@ public class FkhUserSettings : FkhServiceBase
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Gets a global (cluster-wide) setting stored under '_admins'. The runtime value in
+    /// usersettings.json overrides the Terraform-seeded default in defaultusersettings.json.
+    /// </summary>
+    public async Task<JsonNode?> GetGlobalSettingAsync(string property)
+    {
+        var allSettings = await ReadAllSettingsAsync();
+        var defaultSettings = await ReadDefaultSettingsAsync();
+
+        JsonNode? result = null;
+        if (defaultSettings.TryGetPropertyValue(AdminsKey, out var defNode) && defNode is JsonObject defObj
+            && defObj.TryGetPropertyValue(property, out var defValue))
+            result = defValue?.DeepClone();
+        if (allSettings.TryGetPropertyValue(AdminsKey, out var rtNode) && rtNode is JsonObject rtObj
+            && rtObj.TryGetPropertyValue(property, out var rtValue))
+            result = rtValue?.DeepClone();
+        return result;
     }
 
     private async Task<JsonObject> ReadAllSettingsAsync()

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -322,6 +322,10 @@ variable "default_user_settings" {
         "Weekdays": { "Mon": "06:00-18:00", ... },   // a missing day is off
         "UseNagerHolidays": { "Countries": "DK,DE,DE-BE", "Types": "Public,Bank" }
       }
+    Each weekday value is one of:
+      "HH:mm-HH:mm" - auto-start at the first time, auto-stop at the second.
+      "HH:mm-"      - start-only: auto-start at the time, never auto-stop (manual stop).
+      "-HH:mm"      - stop-only: auto-stop at the time, never auto-start (manual start).
     A day is excluded (cluster off) only when every listed country has a matching holiday.
   DESC
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -309,7 +309,21 @@ variable "contact_email_for_letsencrypt" {
 # ── User Settings ─────────────────────────────────────────────────────────────
 
 variable "default_user_settings" {
-  description = "Default user settings JSON. Deployed to the 'settings/defaultusersettings.json' blob. Keys '_members' and '_admins' define defaults for each role."
+  description = <<-DESC
+    Default user settings JSON. Deployed to the 'settings/defaultusersettings.json' blob.
+    Keys '_members' and '_admins' define defaults for each role. Runtime changes made via
+    'setsettings' are stored separately in 'usersettings.json' and always override these
+    defaults, so 'terraform apply' never clobbers values an admin set at runtime.
+
+    Optional cluster uptime schedule (auto start/stop to save cost) is defined under
+    '_admins.Uptime':
+      "Uptime": {
+        "TimeZone": "Central European Standard Time",
+        "Weekdays": { "Mon": "06:00-18:00", ... },   // a missing day is off
+        "UseNagerHolidays": { "Countries": "DK,DE,DE-BE", "Types": "Public,Bank" }
+      }
+    A day is excluded (cluster off) only when every listed country has a matching holiday.
+  DESC
   type        = string
   default     = <<-EOT
     {


### PR DESCRIPTION
This pull request introduces a scheduled cluster uptime feature, allowing automatic start/stop of the AKS cluster based on a configurable schedule to save costs. It adds support for both recurring schedules (with holiday awareness) and one-off overrides for cluster start/stop times. The changes include updates to documentation, configuration, backend logic, and API parameters to support these features.

**Scheduled Cluster Uptime Feature**

- Added support for configuring a recurring cluster uptime schedule (`Uptime` block) in admin user settings, with options for per-weekday windows, time zone selection, and public holiday exclusion using the Nager.Date API. [[1]](diffhunk://#diff-1a07df63dba99dad10ab037ba2c96f2dd90b99f52238d976f5c286b099c1e818R199-R230) [[2]](diffhunk://#diff-47a88f35ee54177c8d0194af4fe74a1a4d1bacad22dd4ca91fe313c74eb48918R214-R225)
- Implemented new models (`UptimeConfig`, `NagerHolidayConfig`, `ClusterScheduleOverrides`, etc.) for storing and managing schedule settings and runtime overrides.

**Backend and API Enhancements**

- Extended the backend (`FkhClusterControl`, `FkhClusterSchedule`) to enforce the schedule, including one-off start/stop overrides persisted in blob storage, and new methods for schedule-aware cluster operations. [[1]](diffhunk://#diff-16805cca4303d6d67c121ba245f66716f9dbac0bdc6c435497727f33f4b92e2bR1-R15) [[2]](diffhunk://#diff-16805cca4303d6d67c121ba245f66716f9dbac0bdc6c435497727f33f4b92e2bR31-R50) [[3]](diffhunk://#diff-16805cca4303d6d67c121ba245f66716f9dbac0bdc6c435497727f33f4b92e2bL47-R165)
- Updated the `AutoStopFunction` to check and apply the cluster schedule on a timer, ensuring the cluster state matches the configured schedule. [[1]](diffhunk://#diff-cfdbf6eadf3459a8ed28bb501765acef9e01255461549defe668fc12ae3dd18bR12-R19) [[2]](diffhunk://#diff-cfdbf6eadf3459a8ed28bb501765acef9e01255461549defe668fc12ae3dd18bR42-R50)
- Registered new singleton services (`FkhHolidayService`, `FkhClusterSchedule`) for schedule and holiday management.

**API and Function Catalog Changes**

- Enhanced the API for `StartFkh` and `StopFkh` to accept `autostop`/`autostart` parameters, allowing one-off schedule overrides, and updated responses to include the next scheduled action. [[1]](diffhunk://#diff-133b3defff5b66955ec9b12d74ee56829b30e45d385c2ab8a139a3d2cecd9145R868-R875) [[2]](diffhunk://#diff-133b3defff5b66955ec9b12d74ee56829b30e45d385c2ab8a139a3d2cecd9145L877-R895) [[3]](diffhunk://#diff-16805cca4303d6d67c121ba245f66716f9dbac0bdc6c435497727f33f4b92e2bR31-R50) [[4]](diffhunk://#diff-16805cca4303d6d67c121ba245f66716f9dbac0bdc6c435497727f33f4b92e2bL47-R165)

**Documentation Updates**

- Updated documentation and configuration examples to describe the new scheduling options and how to use one-off overrides at runtime. [[1]](diffhunk://#diff-1a07df63dba99dad10ab037ba2c96f2dd90b99f52238d976f5c286b099c1e818R199-R230) [[2]](diffhunk://#diff-47a88f35ee54177c8d0194af4fe74a1a4d1bacad22dd4ca91fe313c74eb48918R214-R225)

These changes provide flexible, cost-saving automation for cluster operations, with both default schedules and runtime overrides, and improve visibility and control for administrators.