### PR TITLE
Fix Confirm on RemoveFile and RemoveDatabase

### DIFF
--- a/fkh-backend/FunctionBase.cs
+++ b/fkh-backend/FunctionBase.cs
@@ -240,6 +240,16 @@ public abstract class FunctionBase
 
         // Validate non-file parameters
         var allowedNames = auth.Function.Parameters.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Confirmation-required functions must receive confirm=true; 'confirm' is reserved and never reaches the handler.
+        if (auth.Function.RequiresConfirmation)
+        {
+            parameters.TryGetValue("confirm", out var confirmValue);
+            parameters.Remove("confirm");
+            if (!string.Equals(confirmValue, "true", StringComparison.OrdinalIgnoreCase))
+                return Respond(req, HttpStatusCode.BadRequest, $"{auth.Function.Name} requires confirmation. Pass --confirm to proceed.");
+        }
+
         var unknown = parameters.Keys.Where(k => !allowedNames.Contains(k)).ToList();
         if (unknown.Count > 0)
             return Respond(req, HttpStatusCode.BadRequest, $"Unknown parameters for {auth.Function.Name}: {string.Join(", ", unknown)}.");
@@ -986,6 +996,18 @@ public abstract class FunctionBase
         var internalParams = incoming.Where(kv => kv.Key.StartsWith('_')).ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
         foreach (var key in internalParams.Keys)
             incoming.Remove(key);
+
+        // 'confirm' is a reserved client-side gate for confirmation-required functions; ignore it unless explicitly declared.
+        if (function.RequiresConfirmation)
+        {
+            incoming.TryGetValue("confirm", out var confirmValue);
+            incoming.Remove("confirm");
+            if (!string.Equals(confirmValue, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                return ParameterValidationResult.Fail(
+                    $"{function.Name} requires confirmation. Pass --confirm to proceed.");
+            }
+        }
 
         var unknown = incoming.Keys.Where(k => !allowedNames.Contains(k)).ToList();
         if (unknown.Count > 0)

--- a/fkh-backend/FunctionBase.cs
+++ b/fkh-backend/FunctionBase.cs
@@ -997,7 +997,7 @@ public abstract class FunctionBase
         foreach (var key in internalParams.Keys)
             incoming.Remove(key);
 
-        // 'confirm' is a reserved client-side gate for confirmation-required functions; ignore it unless explicitly declared.
+        // 'confirm' is a reserved parameter for confirmation-required functions; validate it here and do not forward it to the handler.
         if (function.RequiresConfirmation)
         {
             incoming.TryGetValue("confirm", out var confirmValue);

--- a/fkh-backend/FunctionBase.cs
+++ b/fkh-backend/FunctionBase.cs
@@ -247,7 +247,7 @@ public abstract class FunctionBase
             parameters.TryGetValue("confirm", out var confirmValue);
             parameters.Remove("confirm");
             if (!string.Equals(confirmValue, "true", StringComparison.OrdinalIgnoreCase))
-                return Respond(req, HttpStatusCode.BadRequest, $"{auth.Function.Name} requires confirmation. Pass --confirm to proceed.");
+                return Respond(req, HttpStatusCode.BadRequest, $"{auth.Function.Name} requires confirmation. Set confirm=true to proceed (CLI: pass --confirm).");
         }
 
         var unknown = parameters.Keys.Where(k => !allowedNames.Contains(k)).ToList();

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -856,17 +856,7 @@ public static class FunctionCatalog
             Route = "StopFkh",
             AdminOnly = true,
             RequiresConfirmation = true,
-            Parameters = new List<FunctionParameterDefinition>
-            {
-                new()
-                {
-                    Name = "confirm",
-                    Type = "boolean",
-                    Description = "Confirm that you want to stop the cluster.",
-                    Required = false,
-                    DefaultValue = null
-                }
-            }
+            Parameters = new List<FunctionParameterDefinition>()
         },
         new FunctionDefinition
         {

--- a/fkh-backend/Services/FkhClusterControl.cs
+++ b/fkh-backend/Services/FkhClusterControl.cs
@@ -16,12 +16,6 @@ public class FkhClusterControl : FkhServiceBase
 
     public async Task<object> StopClusterAsync(Dictionary<string, string> parameters)
     {
-        if (!parameters.TryGetValue("confirm", out var confirm) ||
-            !string.Equals(confirm, "true", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException("This will stop the entire AKS cluster and all containers. Pass --confirm to proceed.");
-        }
-
         var cluster = GetClusterResource();
         var data = (await cluster.GetAsync()).Value.Data;
         var powerState = data.PowerStateCode?.ToString();

--- a/fkh-cli/Program.cs
+++ b/fkh-cli/Program.cs
@@ -477,6 +477,10 @@ static ParsedArgs ParseArgs(string[] args, FunctionCatalogResponse catalog)
         function.Parameters.Where(p => string.Equals(p.Type, "boolean", StringComparison.OrdinalIgnoreCase)).Select(p => p.Name),
         StringComparer.OrdinalIgnoreCase);
 
+    // 'confirm' is a reserved boolean flag that skips the interactive prompt for confirmation-required functions.
+    if (function.RequiresConfirmation)
+        booleanParams.Add("confirm");
+
     for (var i = 1; i < args.Length; i++)
     {
         var arg = args[i];
@@ -628,6 +632,11 @@ static async Task<FunctionCatalogResponse> GetFunctionCatalogAsync(string? backe
 static void EnsureRequiredParameters(FunctionDefinition function, Dictionary<string, string> parameters)
 {
     var knownNames = function.Parameters.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    // 'confirm' is a reserved flag that skips the interactive prompt for confirmation-required functions.
+    if (function.RequiresConfirmation)
+        knownNames.Add("confirm");
+
     var unknown = parameters.Keys.Where(k => !knownNames.Contains(k)).ToList();
     if (unknown.Count > 0)
     {
@@ -737,6 +746,13 @@ static void PrintCommandUsage(FunctionDefinition function)
         }
     }
     Console.WriteLine();
+    if (function.RequiresConfirmation &&
+        !function.Parameters.Any(p => string.Equals(p.Name, "confirm", StringComparison.OrdinalIgnoreCase)))
+    {
+        Console.WriteLine("Confirmation:");
+        Console.WriteLine("    --confirm           Skip the interactive confirmation prompt");
+        Console.WriteLine();
+    }
     PrintCommonOptions();
 }
 


### PR DESCRIPTION
This pull request refactors how confirmation is handled for sensitive operations (like stopping the cluster) by making `--confirm` a reserved parameter, rather than a regular function parameter. The logic for requiring confirmation is now enforced at a higher level in both the backend and CLI, and the parameter is no longer passed to handler methods or listed in function definitions.

**Confirmation Handling Improvements:**

* The `--confirm` flag is now treated as a reserved parameter for functions that require confirmation, and is no longer listed in the `Parameters` of such functions (e.g., `StopFkh`).
* Both backend (`FunctionBase.cs`) and CLI (`Program.cs`) now check for the presence of `--confirm` for confirmation-required functions and return an error if it is missing, instead of passing it down to the handler. [[1]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR243-R252) [[2]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR1000-R1011) [[3]](diffhunk://#diff-6f9562eed5282ef70942e1e8cf5d2463fc6e76594553e9e87adba3cb1b110491R480-R483) [[4]](diffhunk://#diff-6f9562eed5282ef70942e1e8cf5d2463fc6e76594553e9e87adba3cb1b110491R635-R639)
* The confirmation check was removed from the handler method `StopClusterAsync`, since it is now enforced earlier in the execution flow.

**CLI Usability Improvements:**

* The CLI help output now documents the `--confirm` flag for confirmation-required functions, clarifying its purpose to users.