### PR TITLE
Default database and file version and sort versions alphabetically

### DIFF
--- a/fkh-backend/Services/FkhBackupDatabaseBase.cs
+++ b/fkh-backend/Services/FkhBackupDatabaseBase.cs
@@ -55,6 +55,24 @@ public abstract class FkhBackupDatabaseBase : FkhServiceBase
             var blobContainerClient = blobServiceClient.GetBlobContainerClient("databases");
             await blobContainerClient.CreateIfNotExistsAsync();
 
+            // Reuse the existing version's casing so a re-upload overwrites the same blob instead of creating a case-variant duplicate.
+            try
+            {
+                var existingManifestResponse = await blobContainerClient
+                    .GetBlobClient($"{backupName}/all.json").DownloadContentAsync();
+                var existingManifest = JsonSerializer.Deserialize<DatabaseManifest>(
+                    existingManifestResponse.Value.Content.ToString(),
+                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                var existingVersion = existingManifest?.Versions.FirstOrDefault(
+                    v => string.Equals(v, backupVersion, StringComparison.OrdinalIgnoreCase));
+                if (existingVersion is not null)
+                    backupVersion = existingVersion;
+            }
+            catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+            {
+                // No manifest yet; nothing to normalize.
+            }
+
             var delegationKey = await blobServiceClient.GetUserDelegationKeyAsync(
                 DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddMinutes(60));
 
@@ -122,6 +140,7 @@ public abstract class FkhBackupDatabaseBase : FkhServiceBase
             {
                 manifest.Versions.Add(backupVersion);
             }
+            manifest.Versions.Sort(StringComparer.OrdinalIgnoreCase);
             manifest.Latest = backupVersion;
 
             var manifestJson = JsonSerializer.Serialize(manifest, new JsonSerializerOptions

--- a/fkh-cli/Commands/UploadDatabaseCommand.cs
+++ b/fkh-cli/Commands/UploadDatabaseCommand.cs
@@ -6,7 +6,7 @@ sealed class UploadDatabaseCommand : VersionedBlobCommand
     [
         new() { Name = "bakFile", Type = "file", Description = "Path to the .bak database backup file.", Required = true },
         new() { Name = "backupName", Type = "string", Description = "Backup name (used as the folder name in blob storage).", Required = true },
-        new() { Name = "backupVersion", Type = "string", Description = "Version label for this backup (used as the blob name). Defaults to the current UTC time as YYYYMMDDHHMM.", Required = false }
+        new() { Name = "backupVersion", Type = "string", Description = "Version label for this backup (used as the blob name). Defaults to the current UTC time as yyyyMMddHHmm.", Required = false }
     ];
 
     private static readonly UploadSpec Spec = new()

--- a/fkh-cli/Commands/UploadDatabaseCommand.cs
+++ b/fkh-cli/Commands/UploadDatabaseCommand.cs
@@ -6,7 +6,7 @@ sealed class UploadDatabaseCommand : VersionedBlobCommand
     [
         new() { Name = "bakFile", Type = "file", Description = "Path to the .bak database backup file.", Required = true },
         new() { Name = "backupName", Type = "string", Description = "Backup name (used as the folder name in blob storage).", Required = true },
-        new() { Name = "backupVersion", Type = "string", Description = "Version label for this backup (used as the blob name).", Required = true }
+        new() { Name = "backupVersion", Type = "string", Description = "Version label for this backup (used as the blob name). Defaults to the current UTC time as YYYYMMDDHHMM.", Required = false }
     ];
 
     private static readonly UploadSpec Spec = new()

--- a/fkh-cli/Commands/UploadFileCommand.cs
+++ b/fkh-cli/Commands/UploadFileCommand.cs
@@ -6,7 +6,7 @@ sealed class UploadFileCommand : VersionedBlobCommand
     [
         new() { Name = "localPath", Type = "file", Description = "Path to the local file to upload.", Required = true },
         new() { Name = "FileName", Type = "string", Description = "File name (used as the folder name in blob storage).", Required = true },
-        new() { Name = "FileVersion", Type = "string", Description = "Version label for this file (used as the blob name). Defaults to the current UTC time as YYYYMMDDHHMM.", Required = false }
+        new() { Name = "FileVersion", Type = "string", Description = "Version label for this file (used as the blob name). Defaults to the current UTC time as yyyyMMddHHmm.", Required = false }
     ];
 
     private static readonly UploadSpec Spec = new()

--- a/fkh-cli/Commands/UploadFileCommand.cs
+++ b/fkh-cli/Commands/UploadFileCommand.cs
@@ -6,7 +6,7 @@ sealed class UploadFileCommand : VersionedBlobCommand
     [
         new() { Name = "localPath", Type = "file", Description = "Path to the local file to upload.", Required = true },
         new() { Name = "FileName", Type = "string", Description = "File name (used as the folder name in blob storage).", Required = true },
-        new() { Name = "FileVersion", Type = "string", Description = "Version label for this file (used as the blob name).", Required = true }
+        new() { Name = "FileVersion", Type = "string", Description = "Version label for this file (used as the blob name). Defaults to the current UTC time as YYYYMMDDHHMM.", Required = false }
     ];
 
     private static readonly UploadSpec Spec = new()

--- a/fkh-cli/Commands/VersionedBlobCommand.cs
+++ b/fkh-cli/Commands/VersionedBlobCommand.cs
@@ -104,6 +104,7 @@ abstract class VersionedBlobCommand : ClientCommand
         if (!asJson)
             Console.WriteLine($"{Ansi.Cyan}Uploaded:{Ansi.Reset} {blobName}");
 
+        manifest = await DownloadManifestAsync(manifestClient) ?? manifest;
         if (!manifest.Versions.Contains(version, StringComparer.OrdinalIgnoreCase))
             manifest.Versions.Add(version);
         manifest.Versions.Sort(StringComparer.OrdinalIgnoreCase);

--- a/fkh-cli/Commands/VersionedBlobCommand.cs
+++ b/fkh-cli/Commands/VersionedBlobCommand.cs
@@ -43,8 +43,8 @@ abstract class VersionedBlobCommand : ClientCommand
 
         if (!TryGetRequiredParameter(parameters, spec.NameParameterName, out var name))
             return 1;
-        if (!TryGetRequiredParameter(parameters, spec.VersionParameterName, out var version))
-            return 1;
+        if (!parameters.TryGetValue(spec.VersionParameterName, out var version) || string.IsNullOrWhiteSpace(version))
+            version = DateTime.UtcNow.ToString("yyyyMMddHHmm");
         if (!TryGetRequiredParameter(parameters, spec.LocalPathParameterName, out var localPath))
             return 1;
         if (!File.Exists(localPath))
@@ -62,12 +62,22 @@ abstract class VersionedBlobCommand : ClientCommand
         if (sasUrl is null)
             return 1;
 
+        var containerClient = new Azure.Storage.Blobs.BlobContainerClient(new Uri(sasUrl));
+
+        var manifestBlobName = $"{name}/all.json";
+        var manifestClient = containerClient.GetBlobClient(manifestBlobName);
+        var manifest = await DownloadManifestAsync(manifestClient) ?? new VersionedBlobManifest();
+
+        // Reuse the existing version's casing so a re-upload overwrites the same blob instead of creating a case-variant duplicate.
+        var existingVersion = manifest.Versions.FirstOrDefault(v => string.Equals(v, version, StringComparison.OrdinalIgnoreCase));
+        if (existingVersion is not null)
+            version = existingVersion;
+
         var blobName = spec.GetBlobName(name, version);
         var fileSize = new FileInfo(localPath).Length;
         if (!asJson)
             Console.WriteLine($"{Ansi.Dim}Uploading {localPath} ({fileSize / (1024.0 * 1024):N3} Mb) as {blobName}...{Ansi.Reset}");
 
-        var containerClient = new Azure.Storage.Blobs.BlobContainerClient(new Uri(sasUrl));
         var blobClient = containerClient.GetBlobClient(blobName);
 
         await using (var fileStream = File.OpenRead(localPath))
@@ -94,12 +104,9 @@ abstract class VersionedBlobCommand : ClientCommand
         if (!asJson)
             Console.WriteLine($"{Ansi.Cyan}Uploaded:{Ansi.Reset} {blobName}");
 
-        var manifestBlobName = $"{name}/all.json";
-        var manifestClient = containerClient.GetBlobClient(manifestBlobName);
-        var manifest = await DownloadManifestAsync(manifestClient) ?? new VersionedBlobManifest();
-
         if (!manifest.Versions.Contains(version, StringComparer.OrdinalIgnoreCase))
             manifest.Versions.Add(version);
+        manifest.Versions.Sort(StringComparer.OrdinalIgnoreCase);
         manifest.Latest = version;
 
         await UploadManifestAsync(manifestClient, manifest);


### PR DESCRIPTION
This pull request improves the versioning and manifest handling for uploading database and file blobs, focusing on consistent version casing, default version labeling, and manifest sorting. The main goals are to prevent duplicate blobs due to case differences in version labels, simplify CLI usage by making version parameters optional, and ensure version lists are consistently ordered.

**Version casing normalization and manifest handling:**

* When uploading a blob, the code now checks for an existing version label in the manifest (case-insensitive) and reuses its casing to avoid creating duplicate blobs with only casing differences (`fkh-backend/Services/FkhBackupDatabaseBase.cs`, `fkh-cli/Commands/VersionedBlobCommand.cs`). [[1]](diffhunk://#diff-a36562e00e42b4f052971852d44797000e9a88895de4de03e47eddf88bd96078R58-R75) [[2]](diffhunk://#diff-485e39d1006c22bfc69d5617cde8689dcbbc923d8af3c76f8c56b34d1cc27002R65-L70)

* After adding a new version to the manifest, the versions list is sorted case-insensitively to keep the manifest consistent (`fkh-backend/Services/FkhBackupDatabaseBase.cs`, `fkh-cli/Commands/VersionedBlobCommand.cs`). [[1]](diffhunk://#diff-a36562e00e42b4f052971852d44797000e9a88895de4de03e47eddf88bd96078R143) [[2]](diffhunk://#diff-485e39d1006c22bfc69d5617cde8689dcbbc923d8af3c76f8c56b34d1cc27002L97-R109)

**CLI improvements:**

* The `backupVersion` and `FileVersion` parameters are now optional in the CLI (`UploadDatabaseCommand`, `UploadFileCommand`). If omitted, they default to the current UTC timestamp in `YYYYMMDDHHmm` format, simplifying usage (`fkh-cli/Commands/UploadDatabaseCommand.cs`, `fkh-cli/Commands/UploadFileCommand.cs`, `fkh-cli/Commands/VersionedBlobCommand.cs`). [[1]](diffhunk://#diff-efd0e5f2f90352ef8af5f737ae4df215978002c91cbd155e916a00c8dc6d0896L9-R9) [[2]](diffhunk://#diff-d68679eb5218822d59b78104a19af13cdd21e72cec78c0ceb38ac9917856119fL9-R9) [[3]](diffhunk://#diff-485e39d1006c22bfc69d5617cde8689dcbbc923d8af3c76f8c56b34d1cc27002L46-R47)