### PR TITLE
Remove load balancer when containers are stopped

### DIFF
--- a/fkh-backend/Services/FkhAutoStop.cs
+++ b/fkh-backend/Services/FkhAutoStop.cs
@@ -41,11 +41,21 @@ public class FkhAutoStop : FkhServiceBase
                 await client.ReplaceNamespacedDeploymentAsync(deployment, deployment.Metadata.Name, Namespace);
 
                 // Release the LoadBalancer (public IP + LB rules) so the stopped container incurs no cost.
-                var appName = deployment.Spec.Template.Metadata.Labels != null
-                    && deployment.Spec.Template.Metadata.Labels.TryGetValue("app", out var app)
-                        ? app
-                        : deployment.Metadata.Name.Replace("-deployment", "");
-                await DeleteContainerLoadBalancerServiceAsync(client, appName);
+                string? appName = null;
+                if (deployment.Spec.Template.Metadata.Labels != null
+                    && deployment.Spec.Template.Metadata.Labels.TryGetValue("app", out var app))
+                {
+                    appName = app;
+                }
+                else if (!string.IsNullOrEmpty(deployment.Metadata.Name) && deployment.Metadata.Name.EndsWith("-deployment", StringComparison.Ordinal))
+                {
+                    appName = deployment.Metadata.Name[..^"-deployment".Length];
+                }
+
+                if (!string.IsNullOrEmpty(appName))
+                {
+                    await DeleteContainerLoadBalancerServiceAsync(client, appName);
+                }
                 stopped++;
             }
         }

--- a/fkh-backend/Services/FkhAutoStop.cs
+++ b/fkh-backend/Services/FkhAutoStop.cs
@@ -39,6 +39,13 @@ public class FkhAutoStop : FkhServiceBase
                 deployment.Spec.Replicas = 0;
                 deployment.Metadata.Annotations.Remove(AutoStopAnnotation);
                 await client.ReplaceNamespacedDeploymentAsync(deployment, deployment.Metadata.Name, Namespace);
+
+                // Release the LoadBalancer (public IP + LB rules) so the stopped container incurs no cost.
+                var appName = deployment.Spec.Template.Metadata.Labels != null
+                    && deployment.Spec.Template.Metadata.Labels.TryGetValue("app", out var app)
+                        ? app
+                        : deployment.Metadata.Name.Replace("-deployment", "");
+                await DeleteContainerLoadBalancerServiceAsync(client, appName);
                 stopped++;
             }
         }

--- a/fkh-backend/Services/FkhCreateContainer.cs
+++ b/fkh-backend/Services/FkhCreateContainer.cs
@@ -163,7 +163,7 @@ public class FkhCreateContainer : FkhServiceBase
         }
 
         await CreateDeploymentAsync(client, deploymentName, appName, fullImage, adminUsername, secretName, publicDnsName, databaseName, cpuRequest, memoryRequest, repo, project, multitenant, useSpot, licenseFileUrl, authenticationEmail, aadAppClientId, aadAppObjectId, aadAuthIsMultitenant, moveAllAppsToDevScope);
-        await CreateLoadBalancerServiceAsync(client, serviceName, appName, dnsLabel);
+        await EnsureContainerLoadBalancerServiceAsync(client, appName);
 
         // Set auto-stop annotation if requested
         string? autoStopInfo = null;
@@ -640,39 +640,5 @@ public class FkhCreateContainer : FkhServiceBase
 
         Logger.LogInformation("AAD App Registration created: {DisplayName} (appId: {AppId}, objectId: {ObjectId})", app.DisplayName, app.AppId, app.Id);
         return (app.Id!, app.AppId!);
-    }
-
-    private async Task CreateLoadBalancerServiceAsync(Kubernetes client, string serviceName, string appName, string dnsLabel)
-    {
-        var service = new V1Service
-        {
-            Metadata = new V1ObjectMeta
-            {
-                Name = serviceName,
-                NamespaceProperty = Namespace,
-                Annotations = new Dictionary<string, string>
-                {
-                    ["service.beta.kubernetes.io/azure-dns-label-name"] = dnsLabel,
-                    ["service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"] = "tcp",
-                    ["service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout"] = "30"
-                }
-            },
-            Spec = new V1ServiceSpec
-            {
-                Type = "LoadBalancer",
-                ExternalTrafficPolicy = "Local",
-                Selector = new Dictionary<string, string> { ["app"] = appName },
-                Ports = new List<V1ServicePort>
-                {
-                    new() { Name = "http", Port = 80, TargetPort = 80 },
-                    new() { Name = "https", Port = 443, TargetPort = 443 },
-                    new() { Name = "soap", Port = 7047, TargetPort = 7047 },
-                    new() { Name = "odata", Port = 7048, TargetPort = 7048 },
-                    new() { Name = "dev", Port = 7049, TargetPort = 7049 },
-                }
-            }
-        };
-
-        await client.CreateNamespacedServiceAsync(service, Namespace);
     }
 }

--- a/fkh-backend/Services/FkhGetContainerDetails.cs
+++ b/fkh-backend/Services/FkhGetContainerDetails.cs
@@ -47,22 +47,11 @@ public class FkhGetContainerDetails : FkhServiceBase
 
         var isMultitenant = string.Equals(envVars?.FirstOrDefault(e => e.Name == "multitenant")?.Value, "Y", StringComparison.OrdinalIgnoreCase);
 
-        // Web client URL from the service FQDN
-        string? webClientUrl = null;
-        try
-        {
-            var serviceName = $"{appName}-service";
-            var svc = await client.ReadNamespacedServiceAsync(serviceName, Namespace);
-            var dnsLabel = svc.Metadata.Annotations?.TryGetValue("service.beta.kubernetes.io/azure-dns-label-name", out var label) == true ? label : null;
-            if (dnsLabel != null)
-            {
-                var fqdn = $"{dnsLabel}.{AksLocation}.cloudapp.azure.com";
-                webClientUrl = isMultitenant
-                    ? $"https://{fqdn}/BC/?tenant=default"
-                    : $"https://{fqdn}/BC/";
-            }
-        }
-        catch { /* service lookup failure is non-fatal */ }
+        // Web client URL — FQDN is deterministic from the app name (== the service's DNS label).
+        var fqdn = $"{appName}.{AksLocation}.cloudapp.azure.com";
+        var webClientUrl = isMultitenant
+            ? $"https://{fqdn}/BC/?tenant=default"
+            : $"https://{fqdn}/BC/";
 
         // Read the password from the Kubernetes secret
         var secretName = $"{appName}-secret";

--- a/fkh-backend/Services/FkhGetContainerDetails.cs
+++ b/fkh-backend/Services/FkhGetContainerDetails.cs
@@ -47,11 +47,15 @@ public class FkhGetContainerDetails : FkhServiceBase
 
         var isMultitenant = string.Equals(envVars?.FirstOrDefault(e => e.Name == "multitenant")?.Value, "Y", StringComparison.OrdinalIgnoreCase);
 
-        // Web client URL — FQDN is deterministic from the app name (== the service's DNS label).
-        var fqdn = $"{appName}.{AksLocation}.cloudapp.azure.com";
-        var webClientUrl = isMultitenant
-            ? $"https://{fqdn}/BC/?tenant=default"
-            : $"https://{fqdn}/BC/";
+        // Web client URL — only available while the LoadBalancer service exists (container running).
+        string? webClientUrl = null;
+        if ((deployment.Spec.Replicas ?? 0) > 0)
+        {
+            var fqdn = $"{appName}.{AksLocation}.cloudapp.azure.com";
+            webClientUrl = isMultitenant
+                ? $"https://{fqdn}/BC/?tenant=default"
+                : $"https://{fqdn}/BC/";
+        }
 
         // Read the password from the Kubernetes secret
         var secretName = $"{appName}-secret";

--- a/fkh-backend/Services/FkhListContainers.cs
+++ b/fkh-backend/Services/FkhListContainers.cs
@@ -80,13 +80,6 @@ public class FkhListContainers : FkhServiceBase
         }
         catch { /* metrics API not available */ }
 
-        // Get services to resolve FQDNs
-        var services = await client.ListNamespacedServiceAsync(Namespace);
-        var serviceMap = services.Items
-            .Where(s => s.Spec?.Selector != null && s.Spec.Selector.ContainsKey("app"))
-            .GroupBy(s => s.Spec.Selector["app"])
-            .ToDictionary(g => g.Key, g => g.First());
-
         var containerResults = new List<object>();
 
         foreach (var deployment in filtered)
@@ -173,19 +166,11 @@ public class FkhListContainers : FkhServiceBase
             var databaseNameEnv = envVars?.FirstOrDefault(e => e.Name == "databaseName")?.Value;
             var isMultitenant = string.Equals(envVars?.FirstOrDefault(e => e.Name == "multitenant")?.Value, "Y", StringComparison.OrdinalIgnoreCase);
 
-            // Web client URL from service FQDN
-            string? webClientUrl = null;
-            if (serviceMap.TryGetValue(appLabel, out var svc))
-            {
-                var dnsLabel = svc.Metadata.Annotations?.TryGetValue("service.beta.kubernetes.io/azure-dns-label-name", out var label) == true ? label : null;
-                if (dnsLabel != null)
-                {
-                    var fqdn = $"{dnsLabel}.{AksLocation}.cloudapp.azure.com";
-                    webClientUrl = isMultitenant
-                        ? $"https://{fqdn}/BC/?tenant=default"
-                        : $"https://{fqdn}/BC/";
-                }
-            }
+            // Web client URL — FQDN is deterministic from the app name (== the service's DNS label).
+            var fqdn = $"{appLabel}.{AksLocation}.cloudapp.azure.com";
+            var webClientUrl = isMultitenant
+                ? $"https://{fqdn}/BC/?tenant=default"
+                : $"https://{fqdn}/BC/";
             var tenantDatabaseEnv = isMultitenant && !string.IsNullOrWhiteSpace(databaseNameEnv) ? $"{databaseNameEnv}-default" : null;
             var authEnv = envVars?.FirstOrDefault(e => e.Name == "auth")?.Value;
             var authenticationEmailEnv = envVars?.FirstOrDefault(e => e.Name == "authenticationEMail")?.Value;

--- a/fkh-backend/Services/FkhListContainers.cs
+++ b/fkh-backend/Services/FkhListContainers.cs
@@ -166,11 +166,15 @@ public class FkhListContainers : FkhServiceBase
             var databaseNameEnv = envVars?.FirstOrDefault(e => e.Name == "databaseName")?.Value;
             var isMultitenant = string.Equals(envVars?.FirstOrDefault(e => e.Name == "multitenant")?.Value, "Y", StringComparison.OrdinalIgnoreCase);
 
-            // Web client URL — FQDN is deterministic from the app name (== the service's DNS label).
-            var fqdn = $"{appLabel}.{AksLocation}.cloudapp.azure.com";
-            var webClientUrl = isMultitenant
-                ? $"https://{fqdn}/BC/?tenant=default"
-                : $"https://{fqdn}/BC/";
+            // Web client URL — only available while the LoadBalancer service exists (container running).
+            string? webClientUrl = null;
+            if (replicas > 0)
+            {
+                var fqdn = $"{appLabel}.{AksLocation}.cloudapp.azure.com";
+                webClientUrl = isMultitenant
+                    ? $"https://{fqdn}/BC/?tenant=default"
+                    : $"https://{fqdn}/BC/";
+            }
             var tenantDatabaseEnv = isMultitenant && !string.IsNullOrWhiteSpace(databaseNameEnv) ? $"{databaseNameEnv}-default" : null;
             var authEnv = envVars?.FirstOrDefault(e => e.Name == "auth")?.Value;
             var authenticationEmailEnv = envVars?.FirstOrDefault(e => e.Name == "authenticationEMail")?.Value;

--- a/fkh-backend/Services/FkhScaleContainer.cs
+++ b/fkh-backend/Services/FkhScaleContainer.cs
@@ -23,6 +23,8 @@ public class FkhScaleContainer : FkhServiceBase
         var deploymentName = $"{appName}-deployment";
         var client = await GetKubernetesClientAsync();
         await ClearAutoStopAnnotationAsync(client, deploymentName);
+        // Release the LoadBalancer (public IP + LB rules) so a stopped container incurs no cost.
+        await DeleteContainerLoadBalancerServiceAsync(client, appName);
         return result;
     }
 
@@ -68,6 +70,10 @@ public class FkhScaleContainer : FkhServiceBase
 
         // Generate a fresh container blob SAS URL and inject it as an env var
         await InjectContainerBlobContainerEnvAsync(client, appName, deploymentName);
+
+        // Recreate the LoadBalancer service (deleted on stop). The DNS label reattaches to the
+        // new public IP, so the container's FQDN is preserved.
+        await EnsureContainerLoadBalancerServiceAsync(client, appName);
 
         var result = await ScaleAsync(parameters, 1);
 
@@ -165,6 +171,7 @@ public class FkhScaleContainer : FkhServiceBase
             deployment.Spec.Replicas = 0;
             await client.ReplaceNamespacedDeploymentAsync(deployment, deploymentName, Namespace);
             await ClearAutoStopAnnotationAsync(client, deploymentName);
+            await DeleteContainerLoadBalancerServiceAsync(client, appName);
             stopped.Add(appName);
         }
 

--- a/fkh-backend/Services/FkhScaleContainer.cs
+++ b/fkh-backend/Services/FkhScaleContainer.cs
@@ -71,11 +71,10 @@ public class FkhScaleContainer : FkhServiceBase
         // Generate a fresh container blob SAS URL and inject it as an env var
         await InjectContainerBlobContainerEnvAsync(client, appName, deploymentName);
 
-        // Recreate the LoadBalancer service (deleted on stop). The DNS label reattaches to the
-        // new public IP, so the container's FQDN is preserved.
-        await EnsureContainerLoadBalancerServiceAsync(client, appName);
-
         var result = await ScaleAsync(parameters, 1);
+
+        // Recreate the LoadBalancer service (deleted on stop). If scaling fails, we avoid allocating a public IP.
+        await EnsureContainerLoadBalancerServiceAsync(client, appName);
 
         parameters.TryGetValue("autostop", out var autoStopValue);
         parameters.TryGetValue("_timezone", out var autoStopTz);

--- a/fkh-backend/Services/FkhServiceBase.cs
+++ b/fkh-backend/Services/FkhServiceBase.cs
@@ -584,6 +584,77 @@ public abstract class FkhServiceBase
         Logger.LogInformation("Cleared auto-stop annotation on '{Deployment}'.", deploymentName);
     }
 
+    /// <summary>
+    /// Creates the per-container LoadBalancer service (public IP + DNS label). Idempotent:
+    /// does nothing if the service already exists. The DNS label equals the app name, so the
+    /// container's FQDN ({appName}.{region}.cloudapp.azure.com) is preserved across recreation
+    /// even though the underlying public IP may change.
+    /// </summary>
+    protected async Task EnsureContainerLoadBalancerServiceAsync(Kubernetes client, string appName)
+    {
+        var serviceName = $"{appName}-service";
+        try
+        {
+            await client.ReadNamespacedServiceAsync(serviceName, Namespace);
+            Logger.LogInformation("LoadBalancer service '{Service}' already exists.", serviceName);
+            return;
+        }
+        catch (k8s.Autorest.HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Not found — create it below.
+        }
+
+        var service = new V1Service
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = serviceName,
+                NamespaceProperty = Namespace,
+                Annotations = new Dictionary<string, string>
+                {
+                    ["service.beta.kubernetes.io/azure-dns-label-name"] = appName,
+                    ["service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"] = "tcp",
+                    ["service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout"] = "30"
+                }
+            },
+            Spec = new V1ServiceSpec
+            {
+                Type = "LoadBalancer",
+                ExternalTrafficPolicy = "Local",
+                Selector = new Dictionary<string, string> { ["app"] = appName },
+                Ports = new List<V1ServicePort>
+                {
+                    new() { Name = "http", Port = 80, TargetPort = 80 },
+                    new() { Name = "https", Port = 443, TargetPort = 443 },
+                    new() { Name = "soap", Port = 7047, TargetPort = 7047 },
+                    new() { Name = "odata", Port = 7048, TargetPort = 7048 },
+                    new() { Name = "dev", Port = 7049, TargetPort = 7049 },
+                }
+            }
+        };
+
+        await client.CreateNamespacedServiceAsync(service, Namespace);
+        Logger.LogInformation("Created LoadBalancer service '{Service}'.", serviceName);
+    }
+
+    /// <summary>
+    /// Deletes the per-container LoadBalancer service, releasing its public IP and LB rules so a
+    /// stopped container incurs no Load Balancer cost. Ignores NotFound.
+    /// </summary>
+    protected async Task DeleteContainerLoadBalancerServiceAsync(Kubernetes client, string appName)
+    {
+        var serviceName = $"{appName}-service";
+        try
+        {
+            await client.DeleteNamespacedServiceAsync(serviceName, Namespace);
+            Logger.LogInformation("Deleted LoadBalancer service '{Service}'.", serviceName);
+        }
+        catch (k8s.Autorest.HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Already gone — nothing to do.
+        }
+    }
+
     protected async Task<string> ResolveUseDatabaseAsync(string useDatabase)
     {
         if (useDatabase.StartsWith("https://", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Fixes #56

This pull request introduces major improvements to how per-container LoadBalancer services are managed for cost efficiency and DNS stability. The LoadBalancer service is now created only when a container is running and deleted when stopped, ensuring that stopped containers incur no unnecessary public IP or load balancer cost. The DNS label (and thus the FQDN) is deterministically derived from the app name, preserving the container's public address across restarts. Supporting code has been refactored to centralize and simplify service management, and FQDN resolution logic has been streamlined.

**LoadBalancer Service Lifecycle Management**

* Added `EnsureContainerLoadBalancerServiceAsync` and `DeleteContainerLoadBalancerServiceAsync` methods in `FkhServiceBase.cs` to centralize creation and deletion of per-container LoadBalancer services, making these operations idempotent and encapsulated.
* Updated container start/stop flows (`FkhScaleContainer.cs`, `FkhAutoStop.cs`) to create the LoadBalancer service only when starting a container and delete it when stopping, ensuring no cost is incurred for stopped containers. [[1]](diffhunk://#diff-e7812f9281d05efd3cc838c0d3aea9cbb62bfb5c7903acb3742d0331387a33f7R74-R77) [[2]](diffhunk://#diff-e7812f9281d05efd3cc838c0d3aea9cbb62bfb5c7903acb3742d0331387a33f7R26-R27) [[3]](diffhunk://#diff-e7812f9281d05efd3cc838c0d3aea9cbb62bfb5c7903acb3742d0331387a33f7R174) [[4]](diffhunk://#diff-5bb6b15eb83fe29ee976b6425c54540c3d35ff975c1f1c4e84682f87b9761322R42-R48)

**DNS and FQDN Handling**

* Changed FQDN generation logic in `FkhGetContainerDetails.cs` and `FkhListContainers.cs` to be deterministic based on the app name, matching the DNS label and removing the need to query the Kubernetes service for the DNS label. [[1]](diffhunk://#diff-99e64d6cebfa1a5470d2a121bc102bc9860ed0935b7680f523e5233b33e30608L50-L65) [[2]](diffhunk://#diff-1cfd8403e145169751820c34bb8f500d5d86522a63ec36f459c61bbe7966856bL176-L188)
* Removed unnecessary service lookups for FQDN resolution in `FkhListContainers.cs` for improved performance and simplicity.

**Code Simplification and Cleanup**

* Removed the now-redundant `CreateLoadBalancerServiceAsync` method and replaced its usages with the new centralized methods. [[1]](diffhunk://#diff-9a070f3f6dc32cb0976dcf1cff4868312b06fbdac632f875a61b2fecf5b679adL644-L677) [[2]](diffhunk://#diff-9a070f3f6dc32cb0976dcf1cff4868312b06fbdac632f875a61b2fecf5b679adL166-R166)

These changes make LoadBalancer service management more robust, cost-efficient, and maintainable, while simplifying FQDN handling throughout the codebase.