### PR TITLE
Add openports parameter

### DIFF
--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -145,7 +145,7 @@ public static class FunctionCatalog
                 {
                     Name = "openports",
                     Type = "string",
-                    Description = "Comma-separated list of service ports to open on the load balancer, by name or number (case-insensitive): soap (7047), odata (7048), dev (7049), snapshot (7083). The web ports 80/443 are always open.",
+                    Description = "Comma-separated list of service ports to open on the load balancer. Each entry is a port number (1-65535) or a known name: soap (7047), odata (7048), dev (7049), snapshot (7083). The web ports 80/443 are always open.",
                     Required = false,
                     DefaultValue = "soap,odata,dev"
                 }

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -140,6 +140,14 @@ public static class FunctionCatalog
                     Description = "Email address for Azure AD authentication. When set, the container uses AAD auth instead of NavUserPassword. Requires AAD App Registration setup — see docs/AadAuthentication.md.",
                     Required = false,
                     DefaultValue = null
+                },
+                new()
+                {
+                    Name = "openports",
+                    Type = "string",
+                    Description = "Comma-separated list of service ports to open on the load balancer, by name or number (case-insensitive): soap (7047), odata (7048), dev (7049), snapshot (7083). The web ports 80/443 are always open.",
+                    Required = false,
+                    DefaultValue = "soap,odata,dev"
                 }
             }
         },

--- a/fkh-backend/Services/FkhCreateContainer.cs
+++ b/fkh-backend/Services/FkhCreateContainer.cs
@@ -53,6 +53,10 @@ public class FkhCreateContainer : FkhServiceBase
             Environment.GetEnvironmentVariable("AAD_AUTH_IS_MULTITENANT") ?? "false",
             "true", StringComparison.OrdinalIgnoreCase);
 
+        // Validate the requested LoadBalancer ports early and normalize to a canonical, persisted form.
+        var openPortsSpec = parameters.TryGetValue("openports", out var opv) && !string.IsNullOrWhiteSpace(opv) ? opv : null;
+        var openPorts = string.Join(",", ParseOpenPorts(openPortsSpec).Select(x => x.Name));
+
         var imageTag = GetImageTag(artifactUrl);
         var fullImage = $"{AcrLoginServer}/{AcrRepository}:{imageTag}";
         var appName = ResolveNewAppName(parameters);
@@ -162,8 +166,8 @@ public class FkhCreateContainer : FkhServiceBase
             (aadAppObjectId, aadAppClientId) = await CreateAadAppRegistrationAsync(appName, redirectUri, aadAuthIsMultitenant);
         }
 
-        await CreateDeploymentAsync(client, deploymentName, appName, fullImage, adminUsername, secretName, publicDnsName, databaseName, cpuRequest, memoryRequest, repo, project, multitenant, useSpot, licenseFileUrl, authenticationEmail, aadAppClientId, aadAppObjectId, aadAuthIsMultitenant, moveAllAppsToDevScope);
-        await EnsureContainerLoadBalancerServiceAsync(client, appName);
+        await CreateDeploymentAsync(client, deploymentName, appName, fullImage, adminUsername, secretName, publicDnsName, databaseName, cpuRequest, memoryRequest, repo, project, multitenant, useSpot, licenseFileUrl, authenticationEmail, aadAppClientId, aadAppObjectId, aadAuthIsMultitenant, moveAllAppsToDevScope, openPorts);
+        await EnsureContainerLoadBalancerServiceAsync(client, appName, openPorts);
 
         // Set auto-stop annotation if requested
         string? autoStopInfo = null;
@@ -348,7 +352,7 @@ public class FkhCreateContainer : FkhServiceBase
     private async Task CreateDeploymentAsync(
         Kubernetes client, string deploymentName, string appName, string fullImage,
         string adminUsername, string secretName, string publicDnsName, string databaseName,
-        string cpuRequest, string memoryRequest, string? repo, string? project, bool multitenant, bool useSpot, string? licenseFileUrl, string? authenticationEmail, string? aadAppClientId, string? aadAppObjectId, bool aadAuthIsMultitenant, bool moveAllAppsToDevScope)
+        string cpuRequest, string memoryRequest, string? repo, string? project, bool multitenant, bool useSpot, string? licenseFileUrl, string? authenticationEmail, string? aadAppClientId, string? aadAppObjectId, bool aadAuthIsMultitenant, bool moveAllAppsToDevScope, string? openPorts)
     {
         var annotations = new Dictionary<string, string>();
         if (!string.IsNullOrWhiteSpace(repo))
@@ -359,6 +363,8 @@ public class FkhCreateContainer : FkhServiceBase
             annotations["fkh/aad-app-object-id"] = aadAppObjectId;
         if (moveAllAppsToDevScope)
             annotations["fkh/dev-scope"] = "true";
+        if (!string.IsNullOrWhiteSpace(openPorts))
+            annotations[OpenPortsAnnotation] = openPorts;
 
         var nodeSelector = new Dictionary<string, string>
         {

--- a/fkh-backend/Services/FkhCreateContainer.cs
+++ b/fkh-backend/Services/FkhCreateContainer.cs
@@ -55,7 +55,7 @@ public class FkhCreateContainer : FkhServiceBase
 
         // Validate the requested LoadBalancer ports early and normalize to a canonical, persisted form.
         var openPortsSpec = parameters.TryGetValue("openports", out var opv) && !string.IsNullOrWhiteSpace(opv) ? opv : null;
-        var openPorts = string.Join(",", ParseOpenPorts(openPortsSpec).Select(x => x.Name));
+        var openPorts = string.Join(",", ParseOpenPorts(openPortsSpec));
 
         var imageTag = GetImageTag(artifactUrl);
         var fullImage = $"{AcrLoginServer}/{AcrRepository}:{imageTag}";

--- a/fkh-backend/Services/FkhScaleContainer.cs
+++ b/fkh-backend/Services/FkhScaleContainer.cs
@@ -74,7 +74,9 @@ public class FkhScaleContainer : FkhServiceBase
         var result = await ScaleAsync(parameters, 1);
 
         // Recreate the LoadBalancer service (deleted on stop). If scaling fails, we avoid allocating a public IP.
-        await EnsureContainerLoadBalancerServiceAsync(client, appName);
+        string? openPorts = null;
+        deployment.Metadata.Annotations?.TryGetValue(OpenPortsAnnotation, out openPorts);
+        await EnsureContainerLoadBalancerServiceAsync(client, appName, openPorts);
 
         parameters.TryGetValue("autostop", out var autoStopValue);
         parameters.TryGetValue("_timezone", out var autoStopTz);

--- a/fkh-backend/Services/FkhServiceBase.cs
+++ b/fkh-backend/Services/FkhServiceBase.cs
@@ -504,6 +504,56 @@ public abstract class FkhServiceBase
     }
 
     protected const string AutoStopAnnotation = "fkh/auto-stop-at";
+    protected const string OpenPortsAnnotation = "fkh/open-ports";
+
+    /// <summary>Default LoadBalancer ports opened (in addition to the always-open web ports 80/443).</summary>
+    public const string DefaultOpenPorts = "soap,odata,dev";
+
+    // Toggleable BC service endpoints exposed through the container LoadBalancer.
+    private static readonly IReadOnlyDictionary<string, int> NamedPorts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["soap"] = 7047,
+        ["odata"] = 7048,
+        ["dev"] = 7049,
+        ["snapshot"] = 7083,
+    };
+
+    /// <summary>
+    /// Parses a comma-separated open-ports spec (case-insensitive names or port numbers) into an
+    /// ordered, de-duplicated list. Ports 80/443 are always open and are not part of this list.
+    /// Falls back to <see cref="DefaultOpenPorts"/> when the spec is empty. Throws on unknown values.
+    /// </summary>
+    protected static List<(string Name, int Port)> ParseOpenPorts(string? spec)
+    {
+        if (string.IsNullOrWhiteSpace(spec))
+            spec = DefaultOpenPorts;
+
+        var result = new List<(string Name, int Port)>();
+        foreach (var raw in spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            string name;
+            int port;
+            if (NamedPorts.TryGetValue(raw, out var mapped))
+            {
+                name = raw.ToLowerInvariant();
+                port = mapped;
+            }
+            else if (int.TryParse(raw, out var num) && NamedPorts.Any(kv => kv.Value == num))
+            {
+                var kv = NamedPorts.First(kv => kv.Value == num);
+                name = kv.Key;
+                port = kv.Value;
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"Invalid port '{raw}'. Allowed values: soap (7047), odata (7048), dev (7049), snapshot (7083).");
+            }
+            if (!result.Any(r => r.Port == port))
+                result.Add((name, port));
+        }
+        return result;
+    }
 
     /// <summary>
     /// Parses an autostop value. Accepts:
@@ -590,7 +640,7 @@ public abstract class FkhServiceBase
     /// container's FQDN ({appName}.{region}.cloudapp.azure.com) is preserved across recreation
     /// even though the underlying public IP may change.
     /// </summary>
-    protected async Task EnsureContainerLoadBalancerServiceAsync(Kubernetes client, string appName)
+    protected async Task EnsureContainerLoadBalancerServiceAsync(Kubernetes client, string appName, string? openPortsSpec = null)
     {
         var serviceName = $"{appName}-service";
         try
@@ -603,6 +653,15 @@ public abstract class FkhServiceBase
         {
             // Not found — create it below.
         }
+
+        // Web ports 80/443 are always open; the remaining service endpoints are opt-in via openPortsSpec.
+        var ports = new List<V1ServicePort>
+        {
+            new() { Name = "http", Port = 80, TargetPort = 80 },
+            new() { Name = "https", Port = 443, TargetPort = 443 },
+        };
+        foreach (var (portName, portNumber) in ParseOpenPorts(openPortsSpec))
+            ports.Add(new() { Name = portName, Port = portNumber, TargetPort = portNumber });
 
         var service = new V1Service
         {
@@ -622,14 +681,7 @@ public abstract class FkhServiceBase
                 Type = "LoadBalancer",
                 ExternalTrafficPolicy = "Local",
                 Selector = new Dictionary<string, string> { ["app"] = appName },
-                Ports = new List<V1ServicePort>
-                {
-                    new() { Name = "http", Port = 80, TargetPort = 80 },
-                    new() { Name = "https", Port = 443, TargetPort = 443 },
-                    new() { Name = "soap", Port = 7047, TargetPort = 7047 },
-                    new() { Name = "odata", Port = 7048, TargetPort = 7048 },
-                    new() { Name = "dev", Port = 7049, TargetPort = 7049 },
-                }
+                Ports = ports
             }
         };
 

--- a/fkh-backend/Services/FkhServiceBase.cs
+++ b/fkh-backend/Services/FkhServiceBase.cs
@@ -519,38 +519,28 @@ public abstract class FkhServiceBase
     };
 
     /// <summary>
-    /// Parses a comma-separated open-ports spec (case-insensitive names or port numbers) into an
-    /// ordered, de-duplicated list. Ports 80/443 are always open and are not part of this list.
-    /// Falls back to <see cref="DefaultOpenPorts"/> when the spec is empty. Throws on unknown values.
+    /// Parses a comma-separated open-ports spec into an ordered, de-duplicated list of port numbers.
+    /// Known names (soap/odata/dev/snapshot, case-insensitive) are resolved to their number; every other
+    /// entry must be a port number 1-65535. Ports 80/443 are always open and are not part of this list.
+    /// Falls back to <see cref="DefaultOpenPorts"/> when the spec is empty. Throws on anything else.
     /// </summary>
-    protected static List<(string Name, int Port)> ParseOpenPorts(string? spec)
+    protected static List<int> ParseOpenPorts(string? spec)
     {
         if (string.IsNullOrWhiteSpace(spec))
             spec = DefaultOpenPorts;
 
-        var result = new List<(string Name, int Port)>();
+        var result = new List<int>();
         foreach (var raw in spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
-            string name;
-            int port;
-            if (NamedPorts.TryGetValue(raw, out var mapped))
+            var token = NamedPorts.TryGetValue(raw, out var mapped) ? mapped.ToString() : raw;
+            if (!int.TryParse(token, out var port) || port is < 1 or > 65535)
             {
-                name = raw.ToLowerInvariant();
-                port = mapped;
-            }
-            else if (int.TryParse(raw, out var num) && NamedPorts.Any(kv => kv.Value == num))
-            {
-                var kv = NamedPorts.First(kv => kv.Value == num);
-                name = kv.Key;
-                port = kv.Value;
-            }
-            else
-            {
+                var knownNames = string.Join(", ", NamedPorts.Select(kv => $"{kv.Key} ({kv.Value})"));
                 throw new ArgumentException(
-                    $"Invalid port '{raw}'. Allowed values: soap (7047), odata (7048), dev (7049), snapshot (7083).");
+                    $"Invalid port '{raw}'. Use a port number (1-65535) or a known name: {knownNames}.");
             }
-            if (!result.Any(r => r.Port == port))
-                result.Add((name, port));
+            if (!result.Contains(port))
+                result.Add(port);
         }
         return result;
     }
@@ -660,8 +650,12 @@ public abstract class FkhServiceBase
             new() { Name = "http", Port = 80, TargetPort = 80 },
             new() { Name = "https", Port = 443, TargetPort = 443 },
         };
-        foreach (var (portName, portNumber) in ParseOpenPorts(openPortsSpec))
-            ports.Add(new() { Name = portName, Port = portNumber, TargetPort = portNumber });
+        foreach (var port in ParseOpenPorts(openPortsSpec))
+        {
+            // Prefer the known BC name for readability; fall back to port-<n> for arbitrary ports.
+            var portName = NamedPorts.FirstOrDefault(kv => kv.Value == port).Key ?? $"port-{port}";
+            ports.Add(new() { Name = portName, Port = port, TargetPort = port });
+        }
 
         var service = new V1Service
         {


### PR DESCRIPTION
Fixes #62 

This pull request adds support for configurable load balancer service ports when creating containers. It introduces a new `openports` parameter that allows users to specify which service ports (besides the always-open web ports 80/443) should be exposed. The change ensures that only the requested ports are opened, with validation and normalization of the input, and persists this configuration as an annotation for later use (e.g., on container restart). The default remains to open SOAP, OData, and Dev ports.

**Configurable Load Balancer Ports:**

* Added a new `openports` parameter to the function catalog, allowing users to specify a comma-separated list of service ports (by name or number) to open on the load balancer (e.g., `soap`, `odata`, `dev`, `snapshot`). The web ports 80/443 are always open.
* Implemented the `ParseOpenPorts` method to validate and normalize the requested ports, supporting both names and numbers, with clear error handling for invalid values.
* Updated the deployment creation and load balancer service logic to use the `openports` parameter, persisting the normalized value as an annotation and ensuring the correct ports are opened on both initial deployment and container restart. [[1]](diffhunk://#diff-9a070f3f6dc32cb0976dcf1cff4868312b06fbdac632f875a61b2fecf5b679adR56-R59) [[2]](diffhunk://#diff-9a070f3f6dc32cb0976dcf1cff4868312b06fbdac632f875a61b2fecf5b679adL165-R170) [[3]](diffhunk://#diff-9a070f3f6dc32cb0976dcf1cff4868312b06fbdac632f875a61b2fecf5b679adL351-R355) [[4]](diffhunk://#diff-9a070f3f6dc32cb0976dcf1cff4868312b06fbdac632f875a61b2fecf5b679adR366-R367) [[5]](diffhunk://#diff-e7812f9281d05efd3cc838c0d3aea9cbb62bfb5c7903acb3742d0331387a33f7L77-R79) [[6]](diffhunk://#diff-494bd24f519f52cd6e3e6b34f50065c2f4b9203d8fa000fded75bcfca6b6a1d9L593-R643) [[7]](diffhunk://#diff-494bd24f519f52cd6e3e6b34f50065c2f4b9203d8fa000fded75bcfca6b6a1d9R657-R665) [[8]](diffhunk://#diff-494bd24f519f52cd6e3e6b34f50065c2f4b9203d8fa000fded75bcfca6b6a1d9L625-R684)

**Annotations and Consistency:**

* Introduced the `fkh/open-ports` annotation to persist the open ports configuration, ensuring consistent behavior across container lifecycle events (e.g., stop/start). [[1]](diffhunk://#diff-9a070f3f6dc32cb0976dcf1cff4868312b06fbdac632f875a61b2fecf5b679adR366-R367) [[2]](diffhunk://#diff-e7812f9281d05efd3cc838c0d3aea9cbb62bfb5c7903acb3742d0331387a33f7L77-R79) [[3]](diffhunk://#diff-494bd24f519f52cd6e3e6b34f50065c2f4b9203d8fa000fded75bcfca6b6a1d9R507-R556)

These changes provide more flexibility and security by exposing only the necessary service endpoints per container.