### PR TITLE
Add support for * in version of artifact setting

### DIFF
--- a/fkh-vsix/src/extension.ts
+++ b/fkh-vsix/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { createReadSettingsOptions, readSettings, getRepoName, getProjects } from './readALGoSettings';
+import { createReadSettingsOptions, readSettings, getRepoName, getProjects, resolveArtifactSetting, getProjectFolder } from './readALGoSettings';
 import { ProjectsTreeProvider, ProjectTreeItem, ContainersTreeProvider, ContainerTreeItem, ImagesTreeProvider, ImageTreeItem, VMsTreeProvider, VMTreeItem } from './containersTreeProvider';
 import { updateLaunchJsonAfterCreate, removeLaunchJsonAfterRemove } from './updateLaunchJson';
 import { PROTOCOL_VERSION, CLIENT_APP } from './protocol';
@@ -1043,6 +1043,17 @@ async function createContainer(project?: string): Promise<void> {
   const artifact = String(settings['artifact'] ?? '');
   const country = String(settings['country'] ?? 'us');
 
+  // Resolve a '*' artifact version to major.minor of the project's Application dependency
+  // (scanned from app.json), mirroring AL-Go's DetermineArtifactUrl.
+  let resolvedArtifact = artifact;
+  try {
+    const projectFolder = getProjectFolder(options.baseFolder, options.project);
+    resolvedArtifact = await resolveArtifactSetting(artifact, projectFolder, settings);
+  } catch (err) {
+    vscode.window.showErrorMessage(`Fkh: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
   // Update the cached fkh settings from the freshly-read AL-Go settings
   const fkhSettings = settings['fkh'];
   cachedFkhSettings = (fkhSettings && typeof fkhSettings === 'object') ? fkhSettings as Record<string, string> : undefined;
@@ -1061,11 +1072,11 @@ async function createContainer(project?: string): Promise<void> {
   outputChannel.appendLine(`  environmentName: ${options.environmentName || '(empty)'}`);
   outputChannel.appendLine(`  customSettings: ${options.customSettings || '(empty)'}`);
 
-  const artifactUrl = artifact || `///${country}/latest`;
+  const artifactUrl = resolvedArtifact || `///${country}/latest`;
 
   outputChannel.appendLine('--- Resolved Settings ---');
   outputChannel.appendLine(`  Country: ${country}`);
-  outputChannel.appendLine(`  Artifact: ${artifactUrl}${!artifact ? ' (defaulted)' : ''}`);
+  outputChannel.appendLine(`  Artifact: ${artifactUrl}${!resolvedArtifact ? ' (defaulted)' : ''}`);
   outputChannel.show(true);
 
   const projectContext = options.project ? `${options.repoName}/${options.project}` : options.repoName;

--- a/fkh-vsix/src/readALGoSettings.ts
+++ b/fkh-vsix/src/readALGoSettings.ts
@@ -545,10 +545,10 @@ async function scanForAppJson(folder: vscode.Uri, out: vscode.Uri[], depth: numb
     return;
   }
   for (const [name, type] of entries) {
-    if (type === vscode.FileType.Directory) {
+    if (type & vscode.FileType.Directory) {
       if (name.startsWith('.') || appScanExcludedDirs.has(name.toLowerCase())) { continue; }
       await scanForAppJson(vscode.Uri.joinPath(folder, name), out, depth + 1);
-    } else if (name.toLowerCase() === 'app.json') {
+    } else if ((type & vscode.FileType.File) && name.toLowerCase() === 'app.json') {
       out.push(vscode.Uri.joinPath(folder, name));
     }
   }

--- a/fkh-vsix/src/readALGoSettings.ts
+++ b/fkh-vsix/src/readALGoSettings.ts
@@ -591,11 +591,7 @@ export async function computeApplicationDependency(
 
   for (const uri of await collectAppJsonUris(projectFolder, settings)) {
     let appJson: Record<string, unknown> | undefined;
-    try {
-      appJson = await readSettingsFile(uri);
-    } catch {
-      continue;
-    }
+    appJson = await readSettingsFile(uri);
     if (!appJson) { continue; }
 
     const appVer = parseVersion(getPropertyIgnoreCase(appJson, 'application'));

--- a/fkh-vsix/src/readALGoSettings.ts
+++ b/fkh-vsix/src/readALGoSettings.ts
@@ -510,6 +510,144 @@ function postProcessSettings(settings: Record<string, unknown>, project: string)
   }
 }
 
+// Directory names skipped when scanning a project for app.json source files.
+const appScanExcludedDirs = new Set([
+  '.git', '.github', '.al-go', '.alpackages', '.altemplates',
+  '.snapshots', '.vscode', 'node_modules', 'bin', 'obj',
+]);
+
+function parseVersion(value: unknown): number[] | undefined {
+  if (typeof value !== 'string' || !value.trim()) { return undefined; }
+  const nums: number[] = [];
+  for (const part of value.trim().split('.')) {
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0) { return undefined; }
+    nums.push(n);
+  }
+  return nums.length > 0 ? nums : undefined;
+}
+
+function compareVersions(a: number[], b: number[]): number {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) { return diff < 0 ? -1 : 1; }
+  }
+  return 0;
+}
+
+async function scanForAppJson(folder: vscode.Uri, out: vscode.Uri[], depth: number): Promise<void> {
+  if (depth > 6) { return; }
+  let entries: [string, vscode.FileType][];
+  try {
+    entries = await vscode.workspace.fs.readDirectory(folder);
+  } catch {
+    return;
+  }
+  for (const [name, type] of entries) {
+    if (type === vscode.FileType.Directory) {
+      if (name.startsWith('.') || appScanExcludedDirs.has(name.toLowerCase())) { continue; }
+      await scanForAppJson(vscode.Uri.joinPath(folder, name), out, depth + 1);
+    } else if (name.toLowerCase() === 'app.json') {
+      out.push(vscode.Uri.joinPath(folder, name));
+    }
+  }
+}
+
+async function collectAppJsonUris(projectFolder: vscode.Uri, settings: Record<string, unknown>): Promise<vscode.Uri[]> {
+  const explicitFolders: string[] = [];
+  for (const key of ['appFolders', 'testFolders', 'bcptTestFolders']) {
+    const value = getPropertyIgnoreCase(settings, key);
+    if (Array.isArray(value)) {
+      explicitFolders.push(...value.filter((f): f is string => typeof f === 'string' && f.trim() !== ''));
+    }
+  }
+
+  const uris: vscode.Uri[] = [];
+  if (explicitFolders.length > 0) {
+    for (const folder of explicitFolders) {
+      const parts = folder.split(/[\\/]+/).filter(p => p && p !== '.');
+      const uri = vscode.Uri.joinPath(projectFolder, ...parts, 'app.json');
+      if (await uriExists(uri)) { uris.push(uri); }
+    }
+    return uris;
+  }
+
+  await scanForAppJson(projectFolder, uris, 0);
+  return uris;
+}
+
+/**
+ * Computes the highest `application` dependency across the project's app.json files,
+ * mirroring AL-Go's AnalyzeRepo. Seeded with the `applicationDependency` setting.
+ * Throws if an app.json is missing the required `application` property.
+ * Returns the version as [major, minor, ...], or undefined if none could be determined.
+ */
+export async function computeApplicationDependency(
+  projectFolder: vscode.Uri,
+  settings: Record<string, unknown>,
+): Promise<number[] | undefined> {
+  let max = parseVersion(getString(settings, 'applicationDependency'));
+
+  for (const uri of await collectAppJsonUris(projectFolder, settings)) {
+    let appJson: Record<string, unknown> | undefined;
+    try {
+      appJson = await readSettingsFile(uri);
+    } catch {
+      continue;
+    }
+    if (!appJson) { continue; }
+
+    const appVer = parseVersion(getPropertyIgnoreCase(appJson, 'application'));
+    if (!appVer) {
+      const relative = uri.path.startsWith(projectFolder.path)
+        ? uri.path.substring(projectFolder.path.length).replace(/^\/+/, '')
+        : uri.path;
+      throw new Error(`'${relative}' is missing the required 'application' property.`);
+    }
+    if (!max || compareVersions(appVer, max) > 0) { max = appVer; }
+  }
+
+  return max;
+}
+
+/**
+ * Resolves an artifact shorthand whose version segment is `*` by substituting the
+ * major.minor of the project's computed Application dependency, matching AL-Go's
+ * DetermineArtifactUrl. Non-`*` and full-URL artifacts are returned unchanged.
+ */
+export async function resolveArtifactSetting(
+  artifact: string,
+  projectFolder: vscode.Uri,
+  settings: Record<string, unknown>,
+): Promise<string> {
+  if (!artifact || artifact.startsWith('https://')) { return artifact; }
+
+  // Shorthand format: storageAccount/type/version/country/select
+  const segments = `${artifact}/////`.split('/');
+  if (segments[2] !== '*') { return artifact; }
+
+  const applicationDependency = await computeApplicationDependency(projectFolder, settings);
+  if (!applicationDependency) {
+    throw new Error(
+      `Artifact setting '${artifact}' uses version '*', but no Application dependency could be determined from app.json in the project.`,
+    );
+  }
+
+  segments[2] = `${applicationDependency[0] ?? 0}.${applicationDependency[1] ?? 0}`;
+  return [segments[0], segments[1], segments[2], segments[3], segments[4]].join('/').replace(/\/+$/, '');
+}
+
+/**
+ * Returns the absolute folder for an AL-Go project. The root project ('.' or empty)
+ * resolves to the base (git root) folder.
+ */
+export function getProjectFolder(baseFolder: vscode.Uri, project: string): vscode.Uri {
+  if (!project || project === '.') { return baseFolder; }
+  const parts = project.split(/[\\/]+/).filter(p => p && p !== '.');
+  return vscode.Uri.joinPath(baseFolder, ...parts);
+}
+
 function getDefaultSettings(repoName: string): Record<string, unknown> {
   return {
     type: 'PTE',


### PR DESCRIPTION
Fixes #67 

This pull request enhances the artifact version resolution for container creation by automatically substituting a `*` artifact version with the major.minor version of the project's `application` dependency, as detected from `app.json` files. This mirrors AL-Go's artifact resolution logic and improves consistency with AL-Go pipelines. The main changes include new helper functions for version parsing, scanning project folders for `app.json` files, and resolving artifact versions.

**Artifact version resolution improvements:**

* Added `resolveArtifactSetting` to replace a `*` artifact version in the artifact setting with the project's computed `application` dependency major.minor version, matching AL-Go's `DetermineArtifactUrl` logic.
* Updated `createContainer` in `extension.ts` to use the resolved artifact version and handle errors if the version cannot be determined. [[1]](diffhunk://#diff-1493d16ff79b81dc59beac9b4e069db8954c162e72f8dda416df708213fce23cR1046-R1056) [[2]](diffhunk://#diff-1493d16ff79b81dc59beac9b4e069db8954c162e72f8dda416df708213fce23cL1064-R1079)

**Project scanning and version utilities:**

* Added helpers for parsing and comparing versions, scanning for `app.json` files (excluding common folders), and computing the highest `application` dependency across all relevant `app.json` files in a project.
* Exported a utility to resolve the absolute folder for a given AL-Go project name.

**Extension API surface:**

* Extended the module exports in `readALGoSettings.ts` to include the new artifact and project folder resolution utilities.