### PR TITLE
Add KeyVault and secret functions

### DIFF
--- a/deployment-repo/config/deployment.tfvars
+++ b/deployment-repo/config/deployment.tfvars
@@ -50,6 +50,7 @@ state_location  = ""             # Azure region for the Terraform state resource
 #                                                                                   |___/     
 aks_sku_tier                 = "Free"             # Free (dev/test, no SLA) | Standard (99.95% SLA) | Premium (99.99% SLA)
 acr_sku                      = "Basic"            # Basic (dev/test) | Standard (production) | Premium (geo-replication)
+keyvault_sku                 = "Standard"         # Standard (software-protected) | Premium (HSM-backed)
 linux_vm_size                = "Standard_D4s_v5"  # v6 not supported for sqlserver
 windows_vm_size              = "Standard_D4s_v5"  # v6 not supported for hyhervisor gen1
 windows_min_node_count       = 0                  # Set to 1 to keep a warm Windows node (~$70-100/mo)

--- a/fkh-backend/FunctionBase.cs
+++ b/fkh-backend/FunctionBase.cs
@@ -906,7 +906,12 @@ public abstract class FunctionBase
         secretName = null;
         if (string.IsNullOrEmpty(value) || value.Length < 3) return false;
         if (value[0] != '@' || value[^1] != '@') return false;
-        secretName = value[1..^1];
+secretName = value[1..^1];
+        if (!secretName.All(char.IsLetterOrDigit))
+        {
+            secretName = null;
+            return false;
+        }
         return true;
     }
 

--- a/fkh-backend/FunctionBase.cs
+++ b/fkh-backend/FunctionBase.cs
@@ -289,6 +289,10 @@ public abstract class FunctionBase
         foreach (var kv in internalParams)
             parameters[kv.Key] = kv.Value;
 
+        // Substitute @secretName@ parameter values with Key Vault secrets
+        var secretError = await ResolveSecretReferencesAsync(req, logger, parameters);
+        if (secretError is not null) return secretError;
+
         // ── Execute operation ─────────────────────────────────────────────────────
         return await RunOperationAsync(req, logger, operationName, auth.Username,
             () => aksOperation(parameters, formFiles));
@@ -467,6 +471,10 @@ public abstract class FunctionBase
         var artifactError = await ResolveArtifactAsync(req, logger, parametersResult.Parameters);
         if (artifactError is not null) return artifactError;
 
+        // Substitute @secretName@ parameter values with Key Vault secrets
+        var secretError = await ResolveSecretReferencesAsync(req, logger, parametersResult.Parameters);
+        if (secretError is not null) return secretError;
+
         // ── Execute operation ─────────────────────────────────────────────────────
         return await RunOperationAsync(req, logger, operationName, auth.Username,
             () => aksOperation(parametersResult.Parameters!));
@@ -503,6 +511,10 @@ public abstract class FunctionBase
 
         var artifactError = await ResolveArtifactAsync(req, logger, parametersResult.Parameters);
         if (artifactError is not null) return artifactError;
+
+        // Substitute @secretName@ parameter values with Key Vault secrets
+        var secretError = await ResolveSecretReferencesAsync(req, logger, parametersResult.Parameters);
+        if (secretError is not null) return secretError;
 
         // Fire the operation on a background thread — do not await
         var parameters = parametersResult.Parameters!;
@@ -840,6 +852,62 @@ public abstract class FunctionBase
         {
             return Respond(req, HttpStatusCode.BadRequest, $"Failed to resolve artifact '{rawArtifact}': {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Substitutes any parameter whose value is a secret reference of the form
+    /// <c>@secretName@</c> with the matching Key Vault secret (personal→org fallback).
+    /// Fails the request if a referenced secret does not exist. Internal (_) parameters
+    /// are never substituted.
+    /// </summary>
+    private static async Task<HttpResponseData?> ResolveSecretReferencesAsync(
+        HttpRequestData req,
+        ILogger logger,
+        Dictionary<string, string> parameters)
+    {
+        var references = parameters
+            .Where(kv => !kv.Key.StartsWith('_') && IsSecretReference(kv.Value, out _))
+            .ToList();
+        if (references.Count == 0)
+            return null;
+
+        var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
+        var isOidc = string.Equals(parameters.GetValueOrDefault("_isOidc"), "true", StringComparison.OrdinalIgnoreCase);
+
+        FkhKeyVault? keyVault = null;
+        foreach (var kv in references)
+        {
+            IsSecretReference(kv.Value, out var secretName);
+            try
+            {
+                keyVault ??= FkhKeyVault.Create(logger);
+                var value = await keyVault.TryGetSecretValueAsync(secretName!, githubUsername, isOidc);
+                if (value is null)
+                    return Respond(req, HttpStatusCode.BadRequest, $"No secret found named '{secretName}' (referenced by parameter '{kv.Key}').");
+
+                parameters[kv.Key] = value;
+                logger.LogInformation("Resolved secret reference for parameter '{Param}' from secret '{Secret}'.", kv.Key, secretName);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to resolve secret '{Secret}' for parameter '{Param}'.", secretName, kv.Key);
+                return Respond(req, HttpStatusCode.BadRequest, $"Failed to resolve secret '{secretName}' for parameter '{kv.Key}': {ex.Message}");
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="value"/> is a secret reference (<c>@name@</c>)
+    /// and outputs the alphanumeric secret name.
+    /// </summary>
+    private static bool IsSecretReference(string? value, out string? secretName)
+    {
+        secretName = null;
+        if (string.IsNullOrEmpty(value) || value.Length < 3) return false;
+        if (value[0] != '@' || value[^1] != '@') return false;
+        secretName = value[1..^1];
+        return true;
     }
 
     /// <summary>

--- a/fkh-backend/FunctionBase.cs
+++ b/fkh-backend/FunctionBase.cs
@@ -282,12 +282,14 @@ public abstract class FunctionBase
         }
 
         ClearFailedAttempts(auth.ClientIp);
+        // Reapply caller-supplied internal params first, then overwrite with trusted
+        // authentication values so clients cannot spoof identity/authorization fields.
+        foreach (var kv in internalParams)
+            parameters[kv.Key] = kv.Value;
         parameters["_githubUsername"] = auth.Username;
         parameters["_isAdmin"] = auth.IsAdmin.ToString();
         parameters["_isSupport"] = auth.IsSupport.ToString();
         parameters["_isOidc"] = auth.IsOidc.ToString();
-        foreach (var kv in internalParams)
-            parameters[kv.Key] = kv.Value;
 
         // Substitute @secretName@ parameter values with Key Vault secrets
         var secretError = await ResolveSecretReferencesAsync(req, logger, parameters);

--- a/fkh-backend/FunctionBase.cs
+++ b/fkh-backend/FunctionBase.cs
@@ -285,6 +285,7 @@ public abstract class FunctionBase
         parameters["_githubUsername"] = auth.Username;
         parameters["_isAdmin"] = auth.IsAdmin.ToString();
         parameters["_isSupport"] = auth.IsSupport.ToString();
+        parameters["_isOidc"] = auth.IsOidc.ToString();
         foreach (var kv in internalParams)
             parameters[kv.Key] = kv.Value;
 
@@ -460,6 +461,7 @@ public abstract class FunctionBase
         parametersResult.Parameters!["_githubUsername"] = auth.Username;
         parametersResult.Parameters!["_isAdmin"] = auth.IsAdmin.ToString();
         parametersResult.Parameters!["_isSupport"] = auth.IsSupport.ToString();
+        parametersResult.Parameters!["_isOidc"] = auth.IsOidc.ToString();
 
         // Resolve artifact shorthand (e.g. "///us/latest") to a full URL
         var artifactError = await ResolveArtifactAsync(req, logger, parametersResult.Parameters);
@@ -497,6 +499,7 @@ public abstract class FunctionBase
         parametersResult.Parameters!["_githubUsername"] = auth.Username;
         parametersResult.Parameters!["_isAdmin"] = auth.IsAdmin.ToString();
         parametersResult.Parameters!["_isSupport"] = auth.IsSupport.ToString();
+        parametersResult.Parameters!["_isOidc"] = auth.IsOidc.ToString();
 
         var artifactError = await ResolveArtifactAsync(req, logger, parametersResult.Parameters);
         if (artifactError is not null) return artifactError;
@@ -572,6 +575,7 @@ public abstract class FunctionBase
         public required string Username { get; init; }
         public required bool IsAdmin { get; init; }
         public required bool IsSupport { get; init; }
+        public required bool IsOidc { get; init; }
         public required string ClientIp { get; init; }
         public required FunctionDefinition Function { get; init; }
     }
@@ -633,6 +637,7 @@ public abstract class FunctionBase
         string username;
         var isAdmin = false;
         var isSupport = false;
+        var isOidc = false;
 
         if (AdoOidcService.IsAdoOidcToken(token))
         {
@@ -647,6 +652,7 @@ public abstract class FunctionBase
 
             username = GetAdoOidcUsername(subject);
             isAdmin = true;
+            isOidc = true;
             logger.LogInformation("Received {Operation} request from ADO OIDC caller: {Subject} (username: {Username}, admin: true)", operationName, subject, username);
         }
         else if (GitHubOidcService.IsOidcToken(token))
@@ -662,6 +668,7 @@ public abstract class FunctionBase
 
             username = repository.Replace('/', '-');
             isAdmin = true;
+            isOidc = true;
             logger.LogInformation("Received {Operation} request from OIDC caller: {Repository} (username: {Username}, admin: true)", operationName, repository, username);
         }
         else
@@ -700,6 +707,7 @@ public abstract class FunctionBase
             Username = username,
             IsAdmin = isAdmin,
             IsSupport = isSupport,
+            IsOidc = isOidc,
             ClientIp = clientIp,
             Function = function
         }, null);

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -1362,7 +1362,7 @@ public static class FunctionCatalog
         new FunctionDefinition
         {
             Name = "GetSecret",
-            Description = "Gets a secret value from the deployment's Key Vault by name. Organization secrets (prefixed with the org name) are admin only; use --personal to read your own secrets (prefixed with your GitHub username). Returns an empty string if the secret does not exist.",
+            Description = "Gets a secret value from the deployment's Key Vault by name. Reads your personal secret (prefixed with your GitHub username) if it exists, otherwise falls back to the organization secret (prefixed with the org name). Returns an empty string if neither exists.",
             Route = "GetSecret",
             Parameters = new List<FunctionParameterDefinition>
             {
@@ -1373,21 +1373,13 @@ public static class FunctionCatalog
                     Description = "Name of the secret to read from the Key Vault. May not contain a dash.",
                     Required = true,
                     DefaultValue = null
-                },
-                new()
-                {
-                    Name = "personal",
-                    Type = "boolean",
-                    Description = "Read a personal secret scoped to your GitHub username instead of an organization secret.",
-                    Required = false,
-                    DefaultValue = "false"
                 }
             }
         },
         new FunctionDefinition
         {
             Name = "SetSecret",
-            Description = "Adds or updates a secret in the deployment's Key Vault. Organization secrets (prefixed with the org name) are admin only; use --personal to set your own secrets (prefixed with your GitHub username).",
+            Description = "Adds or updates a secret in the deployment's Key Vault. By default sets a personal secret scoped to your GitHub username (prefixed with your username); use --allusers to set an organization-wide secret (prefixed with the org name), which is admin only.",
             Route = "SetSecret",
             Parameters = new List<FunctionParameterDefinition>
             {
@@ -1409,9 +1401,9 @@ public static class FunctionCatalog
                 },
                 new()
                 {
-                    Name = "personal",
+                    Name = "allusers",
                     Type = "boolean",
-                    Description = "Set a personal secret scoped to your GitHub username instead of an organization secret.",
+                    Description = "Set an organization-wide secret scoped to the org name instead of a personal secret. Admin only.",
                     Required = false,
                     DefaultValue = "false"
                 }

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -1408,6 +1408,13 @@ public static class FunctionCatalog
                     DefaultValue = "false"
                 }
             }
+        },
+        new FunctionDefinition
+        {
+            Name = "ListSecrets",
+            Description = "Lists the names of all secrets in the deployment's Key Vault. Organization-wide secrets (prefixed with the org name) are returned under 'allUsers', followed by your personal secrets (prefixed with your GitHub username) under a key named after your username. OIDC only lists organization secrets.",
+            Route = "ListSecrets",
+            Parameters = new List<FunctionParameterDefinition>()
         }
     };
 

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -1379,7 +1379,7 @@ public static class FunctionCatalog
         new FunctionDefinition
         {
             Name = "SetSecret",
-            Description = "Adds or updates a secret in the deployment's Key Vault. By default sets a personal secret scoped to your GitHub username (prefixed with your username); use --allusers to set an organization-wide secret (prefixed with the org name), which is admin only.",
+            Description = "Adds, updates, or removes a secret in the deployment's Key Vault. By default sets a personal secret scoped to your GitHub username (prefixed with your username); use --allusers to set an organization-wide secret (prefixed with the org name), which is admin only. Pass an empty secret value to remove the secret.",
             Route = "SetSecret",
             Parameters = new List<FunctionParameterDefinition>
             {
@@ -1395,8 +1395,8 @@ public static class FunctionCatalog
                 {
                     Name = "secret",
                     Type = "string",
-                    Description = "The secret value to store (plain text).",
-                    Required = true,
+                    Description = "The secret value to store (plain text). Pass an empty value to remove the secret.",
+                    Required = false,
                     DefaultValue = null
                 },
                 new()

--- a/fkh-backend/FunctionCatalog.cs
+++ b/fkh-backend/FunctionCatalog.cs
@@ -1358,6 +1358,64 @@ public static class FunctionCatalog
                     DefaultValue = "false"
                 }
             }
+        },
+        new FunctionDefinition
+        {
+            Name = "GetSecret",
+            Description = "Gets a secret value from the deployment's Key Vault by name. Organization secrets (prefixed with the org name) are admin only; use --personal to read your own secrets (prefixed with your GitHub username). Returns an empty string if the secret does not exist.",
+            Route = "GetSecret",
+            Parameters = new List<FunctionParameterDefinition>
+            {
+                new()
+                {
+                    Name = "name",
+                    Type = "string",
+                    Description = "Name of the secret to read from the Key Vault. May not contain a dash.",
+                    Required = true,
+                    DefaultValue = null
+                },
+                new()
+                {
+                    Name = "personal",
+                    Type = "boolean",
+                    Description = "Read a personal secret scoped to your GitHub username instead of an organization secret.",
+                    Required = false,
+                    DefaultValue = "false"
+                }
+            }
+        },
+        new FunctionDefinition
+        {
+            Name = "SetSecret",
+            Description = "Adds or updates a secret in the deployment's Key Vault. Organization secrets (prefixed with the org name) are admin only; use --personal to set your own secrets (prefixed with your GitHub username).",
+            Route = "SetSecret",
+            Parameters = new List<FunctionParameterDefinition>
+            {
+                new()
+                {
+                    Name = "name",
+                    Type = "string",
+                    Description = "Name of the secret to set in the Key Vault. May not contain a dash.",
+                    Required = true,
+                    DefaultValue = null
+                },
+                new()
+                {
+                    Name = "secret",
+                    Type = "string",
+                    Description = "The secret value to store (plain text).",
+                    Required = true,
+                    DefaultValue = null
+                },
+                new()
+                {
+                    Name = "personal",
+                    Type = "boolean",
+                    Description = "Set a personal secret scoped to your GitHub username instead of an organization secret.",
+                    Required = false,
+                    DefaultValue = "false"
+                }
+            }
         }
     };
 

--- a/fkh-backend/GetSecretFunction.cs
+++ b/fkh-backend/GetSecretFunction.cs
@@ -1,0 +1,25 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class GetSecretFunction : FunctionBase
+{
+    private readonly ILogger<GetSecretFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhKeyVault _keyVault;
+
+    public GetSecretFunction(ILogger<GetSecretFunction> logger, GitHubAuthService gitHub, FkhKeyVault keyVault)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _keyVault = keyVault;
+    }
+
+    [Function("GetSecret")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "GetSecret")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "GetSecret", _keyVault.GetSecretAsync, skipClusterCheck: true);
+}

--- a/fkh-backend/ListSecretsFunction.cs
+++ b/fkh-backend/ListSecretsFunction.cs
@@ -1,0 +1,25 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class ListSecretsFunction : FunctionBase
+{
+    private readonly ILogger<ListSecretsFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhKeyVault _keyVault;
+
+    public ListSecretsFunction(ILogger<ListSecretsFunction> logger, GitHubAuthService gitHub, FkhKeyVault keyVault)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _keyVault = keyVault;
+    }
+
+    [Function("ListSecrets")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "ListSecrets")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "ListSecrets", _keyVault.ListSecretsAsync, skipClusterCheck: true);
+}

--- a/fkh-backend/Program.cs
+++ b/fkh-backend/Program.cs
@@ -61,6 +61,7 @@ var host = new HostBuilder()
         services.AddSingleton<FkhGetUser>();
         services.AddSingleton<FkhNewUser>();
         services.AddSingleton<FkhGetContainerDetails>();
+        services.AddSingleton<FkhKeyVault>();
     })
     .Build();
 

--- a/fkh-backend/Services/FkhKeyVault.cs
+++ b/fkh-backend/Services/FkhKeyVault.cs
@@ -62,7 +62,7 @@ public class FkhKeyVault : FkhServiceBase
     /// </summary>
     private (string Name, string SecretName, string Scope, string GithubUsername) ResolveSecretName(Dictionary<string, string> parameters)
     {
-        var name = parameters["name"];
+        var name = parameters["name"].Trim();
         var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
         var isPersonal = parameters.TryGetValue("personal", out var personalVal)
             && string.Equals(personalVal, "true", StringComparison.OrdinalIgnoreCase);
@@ -71,8 +71,8 @@ public class FkhKeyVault : FkhServiceBase
         var isOidc = parameters.TryGetValue("_isOidc", out var oidcVal)
             && string.Equals(oidcVal, "true", StringComparison.OrdinalIgnoreCase);
 
-        if (name.Contains('-'))
-            throw new ArgumentException("Parameter 'name' may not contain a dash.");
+        if (name.Length == 0 || name.Any(c => !char.IsLetterOrDigit(c)))
+            throw new ArgumentException("Parameter 'name' must contain only letters and digits.");
 
         if (isPersonal && isOidc)
             throw new ArgumentException("Personal secrets are not available with OIDC authentication (there is no personal user). Omit --personal to use organization secrets.");

--- a/fkh-backend/Services/FkhKeyVault.cs
+++ b/fkh-backend/Services/FkhKeyVault.cs
@@ -83,7 +83,7 @@ public class FkhKeyVault : FkhServiceBase
     {
         var name = ValidateName(parameters);
         var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
-        var secret = parameters["secret"];
+        var secret = parameters.GetValueOrDefault("secret", "");
         var isAllUsers = IsTrue(parameters, "allusers");
         var isAdmin = IsTrue(parameters, "_isAdmin");
         var isOidc = IsTrue(parameters, "_isOidc");
@@ -97,10 +97,37 @@ public class FkhKeyVault : FkhServiceBase
         var prefix = NormalizePrefix(isAllUsers ? _orgName : githubUsername);
         var secretName = $"{prefix}-{name}";
         var scope = isAllUsers ? "organization" : "personal";
-        Logger.LogInformation("User '{User}' setting {Scope} secret '{Secret}' in Key Vault.", githubUsername, scope, secretName);
-
         var client = CreateClient();
-        await client.SetSecretAsync(secretName, secret);
+
+        // An empty value removes the secret.
+        if (string.IsNullOrEmpty(secret))
+        {
+            Logger.LogInformation("User '{User}' removing {Scope} secret '{Secret}' from Key Vault.", githubUsername, scope, secretName);
+            try
+            {
+                await client.StartDeleteSecretAsync(secretName);
+                return new { Name = name, Message = $"Secret '{name}' removed." };
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                return new { Name = name, Message = $"Secret '{name}' does not exist." };
+            }
+        }
+
+        Logger.LogInformation("User '{User}' setting {Scope} secret '{Secret}' in Key Vault.", githubUsername, scope, secretName);
+        try
+        {
+            await client.SetSecretAsync(secretName, secret);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 409)
+        {
+            // The secret name is in a soft-deleted (recoverable) state and cannot be
+            // reused until recovered or purged. Recover it, then overwrite the value.
+            Logger.LogInformation("Secret '{Secret}' is soft-deleted; recovering before set.", secretName);
+            var recover = await client.StartRecoverDeletedSecretAsync(secretName);
+            await recover.WaitForCompletionAsync();
+            await client.SetSecretAsync(secretName, secret);
+        }
         return new { Name = name, Message = $"Secret '{name}' set." };
     }
 

--- a/fkh-backend/Services/FkhKeyVault.cs
+++ b/fkh-backend/Services/FkhKeyVault.cs
@@ -42,6 +42,43 @@ public class FkhKeyVault : FkhServiceBase
     }
 
     /// <summary>
+    /// Lists the names of all secrets the caller can see: organization-wide secrets
+    /// (prefixed with the org name) under "allUsers", then the caller's personal
+    /// secrets (prefixed with their GitHub username) under a key named after the user.
+    /// OIDC has no personal user and only lists organization secrets.
+    /// </summary>
+    public async Task<object> ListSecretsAsync(Dictionary<string, string> parameters)
+    {
+        var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
+        var isOidc = IsTrue(parameters, "_isOidc");
+
+        var orgPrefix = NormalizePrefix(_orgName) + "-";
+        var userPrefix = NormalizePrefix(githubUsername) + "-";
+
+        var allUsers = new List<string>();
+        var personal = new List<string>();
+
+        var client = CreateClient();
+        await foreach (var prop in client.GetPropertiesOfSecretsAsync())
+        {
+            if (prop.Name.StartsWith(orgPrefix, StringComparison.Ordinal))
+                allUsers.Add(prop.Name[orgPrefix.Length..]);
+            else if (!isOidc && prop.Name.StartsWith(userPrefix, StringComparison.Ordinal))
+                personal.Add(prop.Name[userPrefix.Length..]);
+        }
+
+        allUsers.Sort(StringComparer.OrdinalIgnoreCase);
+        personal.Sort(StringComparer.OrdinalIgnoreCase);
+
+        Logger.LogInformation("User '{User}' listed secrets ({OrgCount} organization, {PersonalCount} personal).", githubUsername, allUsers.Count, personal.Count);
+
+        var result = new Dictionary<string, List<string>> { ["allUsers"] = allUsers };
+        if (!isOidc)
+            result[githubUsername] = personal;
+        return result;
+    }
+
+    /// <summary>
     /// Resolves a secret value using the personal→organization fallback: the caller's
     /// personal secret (username-name) is preferred, then the organization secret
     /// (orgname-name). OIDC has no personal user and reads the organization secret only.

--- a/fkh-backend/Services/FkhKeyVault.cs
+++ b/fkh-backend/Services/FkhKeyVault.cs
@@ -10,13 +10,18 @@ public class FkhKeyVault : FkhServiceBase
     private readonly string _keyVaultUri;
     private readonly string _orgName;
 
-    public FkhKeyVault(ILogger<FkhKeyVault> logger) : base(logger)
+    public FkhKeyVault(ILogger<FkhKeyVault> logger) : this((ILogger)logger) { }
+
+    private FkhKeyVault(ILogger logger) : base(logger)
     {
         _keyVaultUri = Environment.GetEnvironmentVariable("KEYVAULT_URI")
             ?? throw new InvalidOperationException("KEYVAULT_URI is not configured.");
         _orgName = Environment.GetEnvironmentVariable("GITHUB_REPO_OWNER")
             ?? throw new InvalidOperationException("GITHUB_REPO_OWNER is not configured.");
     }
+
+    /// <summary>Creates an instance outside of DI (e.g. for parameter secret substitution).</summary>
+    public static FkhKeyVault Create(ILogger logger) => new(logger);
 
     private SecretClient CreateClient()
     {
@@ -28,25 +33,70 @@ public class FkhKeyVault : FkhServiceBase
 
     public async Task<object> GetSecretAsync(Dictionary<string, string> parameters)
     {
-        var (name, secretName, scope, githubUsername) = ResolveSecretName(parameters);
-        Logger.LogInformation("User '{User}' reading {Scope} secret '{Secret}' from Key Vault.", githubUsername, scope, secretName);
+        var name = ValidateName(parameters);
+        var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
+        var isOidc = IsTrue(parameters, "_isOidc");
 
+        var value = await TryGetSecretValueAsync(name, githubUsername, isOidc);
+        return new { Name = name, Secret = value ?? "" };
+    }
+
+    /// <summary>
+    /// Resolves a secret value using the personal→organization fallback: the caller's
+    /// personal secret (username-name) is preferred, then the organization secret
+    /// (orgname-name). OIDC has no personal user and reads the organization secret only.
+    /// Returns null if no matching secret exists.
+    /// </summary>
+    public async Task<string?> TryGetSecretValueAsync(string name, string githubUsername, bool isOidc)
+    {
         var client = CreateClient();
+
+        if (!isOidc)
+        {
+            var personalSecretName = $"{NormalizePrefix(githubUsername)}-{name}";
+            try
+            {
+                var secret = await client.GetSecretAsync(personalSecretName);
+                Logger.LogInformation("User '{User}' read personal secret '{Secret}' from Key Vault.", githubUsername, personalSecretName);
+                return secret.Value.Value;
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                // No personal secret; fall through to the organization secret.
+            }
+        }
+
+        var orgSecretName = $"{NormalizePrefix(_orgName)}-{name}";
         try
         {
-            var secret = await client.GetSecretAsync(secretName);
-            return new { Name = name, Secret = secret.Value.Value };
+            var secret = await client.GetSecretAsync(orgSecretName);
+            Logger.LogInformation("User '{User}' read organization secret '{Secret}' from Key Vault.", githubUsername, orgSecretName);
+            return secret.Value.Value;
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
-            return new { Name = name, Secret = "" };
+            return null;
         }
     }
 
     public async Task<object> SetSecretAsync(Dictionary<string, string> parameters)
     {
-        var (name, secretName, scope, githubUsername) = ResolveSecretName(parameters);
+        var name = ValidateName(parameters);
+        var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
         var secret = parameters["secret"];
+        var isAllUsers = IsTrue(parameters, "allusers");
+        var isAdmin = IsTrue(parameters, "_isAdmin");
+        var isOidc = IsTrue(parameters, "_isOidc");
+
+        if (isAllUsers && !isAdmin)
+            throw new UnauthorizedAccessException("Organization-wide secrets are admin only. Omit --allusers to set your own personal secret.");
+
+        if (!isAllUsers && isOidc)
+            throw new ArgumentException("Personal secrets are not available with OIDC authentication (there is no personal user). Use --allusers to set an organization-wide secret.");
+
+        var prefix = NormalizePrefix(isAllUsers ? _orgName : githubUsername);
+        var secretName = $"{prefix}-{name}";
+        var scope = isAllUsers ? "organization" : "personal";
         Logger.LogInformation("User '{User}' setting {Scope} secret '{Secret}' in Key Vault.", githubUsername, scope, secretName);
 
         var client = CreateClient();
@@ -55,34 +105,19 @@ public class FkhKeyVault : FkhServiceBase
     }
 
     /// <summary>
-    /// Resolves the prefixed Key Vault secret name and enforces access rules.
-    /// Personal secrets are prefixed with the caller's GitHub username; organization
-    /// secrets are prefixed with the org name and require admin. The name must not
-    /// contain a dash so an admin's org-scoped read can never resolve to a personal secret.
+    /// Validates the secret name. The name must not contain a dash so that a
+    /// personal secret can never collide with the org-prefixed naming scheme.
     /// </summary>
-    private (string Name, string SecretName, string Scope, string GithubUsername) ResolveSecretName(Dictionary<string, string> parameters)
+    private static string ValidateName(Dictionary<string, string> parameters)
     {
         var name = parameters["name"].Trim();
-        var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
-        var isPersonal = parameters.TryGetValue("personal", out var personalVal)
-            && string.Equals(personalVal, "true", StringComparison.OrdinalIgnoreCase);
-        var isAdmin = parameters.TryGetValue("_isAdmin", out var adminVal)
-            && string.Equals(adminVal, "true", StringComparison.OrdinalIgnoreCase);
-        var isOidc = parameters.TryGetValue("_isOidc", out var oidcVal)
-            && string.Equals(oidcVal, "true", StringComparison.OrdinalIgnoreCase);
-
         if (name.Length == 0 || name.Any(c => !char.IsLetterOrDigit(c)))
             throw new ArgumentException("Parameter 'name' must contain only letters and digits.");
-
-        if (isPersonal && isOidc)
-            throw new ArgumentException("Personal secrets are not available with OIDC authentication (there is no personal user). Omit --personal to use organization secrets.");
-
-        if (!isPersonal && !isAdmin)
-            throw new UnauthorizedAccessException("Organization secrets are admin only. Use --personal to manage your own secrets.");
-
-        var prefix = NormalizePrefix(isPersonal ? githubUsername : _orgName);
-        return (name, $"{prefix}-{name}", isPersonal ? "personal" : "organization", githubUsername);
+        return name;
     }
+
+    private static bool IsTrue(Dictionary<string, string> parameters, string key)
+        => parameters.TryGetValue(key, out var val) && string.Equals(val, "true", StringComparison.OrdinalIgnoreCase);
 
     private static string NormalizePrefix(string value)
         => new(value.ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray());

--- a/fkh-backend/Services/FkhKeyVault.cs
+++ b/fkh-backend/Services/FkhKeyVault.cs
@@ -1,0 +1,89 @@
+using Azure;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh.Services;
+
+public class FkhKeyVault : FkhServiceBase
+{
+    private readonly string _keyVaultUri;
+    private readonly string _orgName;
+
+    public FkhKeyVault(ILogger<FkhKeyVault> logger) : base(logger)
+    {
+        _keyVaultUri = Environment.GetEnvironmentVariable("KEYVAULT_URI")
+            ?? throw new InvalidOperationException("KEYVAULT_URI is not configured.");
+        _orgName = Environment.GetEnvironmentVariable("GITHUB_REPO_OWNER")
+            ?? throw new InvalidOperationException("GITHUB_REPO_OWNER is not configured.");
+    }
+
+    private SecretClient CreateClient()
+    {
+#pragma warning disable CS0618
+        var credential = new ManagedIdentityCredential(ClientId);
+#pragma warning restore CS0618
+        return new SecretClient(new Uri(_keyVaultUri), credential);
+    }
+
+    public async Task<object> GetSecretAsync(Dictionary<string, string> parameters)
+    {
+        var (name, secretName, scope, githubUsername) = ResolveSecretName(parameters);
+        Logger.LogInformation("User '{User}' reading {Scope} secret '{Secret}' from Key Vault.", githubUsername, scope, secretName);
+
+        var client = CreateClient();
+        try
+        {
+            var secret = await client.GetSecretAsync(secretName);
+            return new { Name = name, Secret = secret.Value.Value };
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return new { Name = name, Secret = "" };
+        }
+    }
+
+    public async Task<object> SetSecretAsync(Dictionary<string, string> parameters)
+    {
+        var (name, secretName, scope, githubUsername) = ResolveSecretName(parameters);
+        var secret = parameters["secret"];
+        Logger.LogInformation("User '{User}' setting {Scope} secret '{Secret}' in Key Vault.", githubUsername, scope, secretName);
+
+        var client = CreateClient();
+        await client.SetSecretAsync(secretName, secret);
+        return new { Name = name, Message = $"Secret '{name}' set." };
+    }
+
+    /// <summary>
+    /// Resolves the prefixed Key Vault secret name and enforces access rules.
+    /// Personal secrets are prefixed with the caller's GitHub username; organization
+    /// secrets are prefixed with the org name and require admin. The name must not
+    /// contain a dash so an admin's org-scoped read can never resolve to a personal secret.
+    /// </summary>
+    private (string Name, string SecretName, string Scope, string GithubUsername) ResolveSecretName(Dictionary<string, string> parameters)
+    {
+        var name = parameters["name"];
+        var githubUsername = parameters.GetValueOrDefault("_githubUsername", "unknown");
+        var isPersonal = parameters.TryGetValue("personal", out var personalVal)
+            && string.Equals(personalVal, "true", StringComparison.OrdinalIgnoreCase);
+        var isAdmin = parameters.TryGetValue("_isAdmin", out var adminVal)
+            && string.Equals(adminVal, "true", StringComparison.OrdinalIgnoreCase);
+        var isOidc = parameters.TryGetValue("_isOidc", out var oidcVal)
+            && string.Equals(oidcVal, "true", StringComparison.OrdinalIgnoreCase);
+
+        if (name.Contains('-'))
+            throw new ArgumentException("Parameter 'name' may not contain a dash.");
+
+        if (isPersonal && isOidc)
+            throw new ArgumentException("Personal secrets are not available with OIDC authentication (there is no personal user). Omit --personal to use organization secrets.");
+
+        if (!isPersonal && !isAdmin)
+            throw new UnauthorizedAccessException("Organization secrets are admin only. Use --personal to manage your own secrets.");
+
+        var prefix = NormalizePrefix(isPersonal ? githubUsername : _orgName);
+        return (name, $"{prefix}-{name}", isPersonal ? "personal" : "organization", githubUsername);
+    }
+
+    private static string NormalizePrefix(string value)
+        => new(value.ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray());
+}

--- a/fkh-backend/SetSecretFunction.cs
+++ b/fkh-backend/SetSecretFunction.cs
@@ -1,0 +1,25 @@
+using Fkh.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Fkh;
+
+public class SetSecretFunction : FunctionBase
+{
+    private readonly ILogger<SetSecretFunction> _logger;
+    private readonly GitHubAuthService _gitHub;
+    private readonly FkhKeyVault _keyVault;
+
+    public SetSecretFunction(ILogger<SetSecretFunction> logger, GitHubAuthService gitHub, FkhKeyVault keyVault)
+    {
+        _logger = logger;
+        _gitHub = gitHub;
+        _keyVault = keyVault;
+    }
+
+    [Function("SetSecret")]
+    public Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "SetSecret")] HttpRequestData req)
+        => ExecuteAsync(req, _logger, _gitHub, "SetSecret", _keyVault.SetSecretAsync, skipClusterCheck: true);
+}

--- a/fkh-backend/azure-function.csproj
+++ b/fkh-backend/azure-function.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
     <PackageReference Include="Azure.ResourceManager.Compute" Version="1.14.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.5.0" />
     <PackageReference Include="Azure.ResourceManager.ContainerRegistry" Version="1.4.0" />

--- a/fkh-vsix/src/extension.ts
+++ b/fkh-vsix/src/extension.ts
@@ -361,6 +361,37 @@ async function getPublicIp(): Promise<string | undefined> {
   return undefined;
 }
 
+// Returns the secret name if value is a secret reference (@name@), otherwise undefined.
+function parseSecretReference(value: string | undefined): string | undefined {
+  if (!value || value.length < 3) { return undefined; }
+  if (value[0] !== '@' || value[value.length - 1] !== '@') { return undefined; }
+  const inner = value.slice(1, -1);
+  if (inner.length === 0 || !/^[a-zA-Z0-9]+$/.test(inner)) { return undefined; }
+  return inner;
+}
+
+// Resolves a secret value via the backend GetSecret route. Returns an empty string
+// when the secret does not exist or cannot be fetched (never throws).
+async function fetchSecretValue(secretName: string, baseUrl: string, accessToken: string): Promise<string> {
+  try {
+    const response = await fetch(`${baseUrl}/GetSecret`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        'X-Fkh-Protocol-Version': String(PROTOCOL_VERSION),
+        'X-Fkh-Client': CLIENT_APP,
+      },
+      body: JSON.stringify({ parameters: { name: secretName } }),
+    });
+    if (!response.ok) { return ''; }
+    const result = await response.json() as { secret?: string };
+    return result.secret ?? '';
+  } catch {
+    return '';
+  }
+}
+
 async function getGitHubSession(): Promise<vscode.AuthenticationSession | undefined> {
   try {
     // Try to get an existing session silently first (works in vscode.dev where
@@ -570,6 +601,27 @@ async function promptForParameters(
   // If nothing to prompt for, return immediately
   if (promptParams.length === 0) {
     return resolvedDefaults;
+  }
+
+  // Resolve any @secretName@ default to the secret's value before displaying the
+  // dialog. Missing secrets resolve to an empty field (never fails here). The session
+  // and backend URL are resolved once and the secrets are fetched in parallel.
+  const secretRefs = promptParams
+    .map(param => ({ param, secretName: parseSecretReference(resolvedDefaults[param.name] ?? param.defaultValue ?? '') }))
+    .filter((r): r is { param: FunctionParameterDefinition; secretName: string } => r.secretName !== undefined);
+  if (secretRefs.length > 0) {
+    const baseUrl = getBackendUrl();
+    const session = await getGitHubSession();
+    if (baseUrl && session) {
+      await Promise.all(secretRefs.map(async ({ param, secretName }) => {
+        resolvedDefaults[param.name] = await fetchSecretValue(secretName, baseUrl, session.accessToken);
+      }));
+    } else {
+      // No backend/session available — clear the references so raw @name@ isn't shown.
+      for (const { param } of secretRefs) {
+        resolvedDefaults[param.name] = '';
+      }
+    }
   }
 
   // Single parameter: use simple input box

--- a/fkh-vsix/src/extension.ts
+++ b/fkh-vsix/src/extension.ts
@@ -703,7 +703,7 @@ async function promptForParameters(
       let desc = param.description;
       const escapedDesc = desc.replace(/&/g, '&amp;').replace(/</g, '&lt;');
       const requiredBadge = param.required ? '<span class="required">required</span>' : '';
-      const isPassword = param.name.toLowerCase().includes('password');
+      const isPassword = param.name.toLowerCase().includes('password') || param.name.toLowerCase().includes('secret');
 
       if (param.type.toLowerCase() === 'boolean') {
         const checked = defaultVal.toLowerCase() === 'true' ? 'checked' : '';
@@ -713,11 +713,15 @@ async function promptForParameters(
         </div>`;
       }
 
+      const inputHtml = `<input type="${isPassword ? 'password' : 'text'}" id="${param.name}" name="${param.name}"
+          value="${escapedDefault}" placeholder="${escapedDefault || (param.required ? '(required)' : '(optional)')}"${param.required ? ' required' : ''} />`;
+
       return `<div class="field">
         <label for="${param.name}">${param.name} ${requiredBadge}</label>
         <div class="desc">${escapedDesc}</div>
-        <input type="${isPassword ? 'password' : 'text'}" id="${param.name}" name="${param.name}"
-          value="${escapedDefault}" placeholder="${escapedDefault || (param.required ? '(required)' : '(optional)')}"${param.required ? ' required' : ''} />
+        ${isPassword
+          ? `<div class="pw-wrap">${inputHtml}<button type="button" class="pw-toggle" data-target="${param.name}" aria-label="Show value">Show</button></div>`
+          : inputHtml}
       </div>`;
     }).join('\n');
 
@@ -741,6 +745,13 @@ async function promptForParameters(
   }
   input[type="text"]:focus, input[type="password"]:focus { outline: 1px solid var(--vscode-focusBorder); }
   input:invalid { border-color: var(--vscode-errorForeground); }
+  .pw-wrap { display: flex; gap: 6px; align-items: stretch; }
+  .pw-wrap input { flex: 1; }
+  .pw-toggle {
+    padding: 6px 10px; font-size: 12px; white-space: nowrap;
+    background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground);
+  }
+  .pw-toggle:hover { background: var(--vscode-button-secondaryHoverBackground); }
   .buttons { margin-top: 20px; display: flex; gap: 8px; }
   button {
     padding: 6px 16px; border: none; border-radius: 2px; cursor: pointer; font-size: 13px;
@@ -782,6 +793,16 @@ async function promptForParameters(
     document.getElementById('cancelBtn').addEventListener('click', () => {
       vscode.postMessage({ command: 'cancel' });
     });
+    for (const btn of document.querySelectorAll('.pw-toggle')) {
+      btn.addEventListener('click', () => {
+        const input = document.getElementById(btn.getAttribute('data-target'));
+        if (!input) return;
+        const show = input.type === 'password';
+        input.type = show ? 'text' : 'password';
+        btn.textContent = show ? 'Hide' : 'Show';
+        btn.setAttribute('aria-label', show ? 'Hide value' : 'Show value');
+      });
+    }
     // Focus first input
     const first = form.querySelector('input');
     if (first) first.focus();

--- a/fkh-vsix/src/extension.ts
+++ b/fkh-vsix/src/extension.ts
@@ -494,13 +494,19 @@ async function promptForParameters(
   // Apply cached AL-Go fkh settings for this function
   if (cachedFkhSettings) {
     const prefix = `${definition.name}.`;
+    const requiredParams = new Set(
+      definition.parameters.filter(p => p.required).map(p => p.name.toLowerCase())
+    );
     for (const [key, value] of Object.entries(cachedFkhSettings)) {
       if (key.startsWith(prefix)) {
         const paramKey = key.substring(prefix.length);
         const strValue = String(value ?? '').trim();
-        if (paramKey.endsWith('?')) {
-          // Trailing ? means show the parameter with value as default (don't override explicit prefilledDefaults)
-          const cleanKey = paramKey.slice(0, -1);
+        // Required params are always shown (treated like a trailing '?') so a hard
+        // override to a missing secret leaves an empty, required field to fill in.
+        const cleanKey = paramKey.endsWith('?') ? paramKey.slice(0, -1) : paramKey;
+        const asDefault = paramKey.endsWith('?') || requiredParams.has(cleanKey.toLowerCase());
+        if (asDefault) {
+          // Show the parameter with value as default (don't override explicit prefilledDefaults)
           if (!(cleanKey in prefilledDefaults) && strValue) {
             prefilledDefaults[cleanKey] = strValue;
           }

--- a/terraform/function.tf
+++ b/terraform/function.tf
@@ -78,6 +78,7 @@ locals {
     GITHUB_REPO_NAME                       = split("/", var.create_images_repo)[1]
     DBS_STORAGE_ACCOUNT_NAME               = azurerm_storage_account.dbs.name
     LOG_ANALYTICS_WORKSPACE_ID             = azurerm_log_analytics_workspace.this.id
+    KEYVAULT_URI                           = azurerm_key_vault.this.vault_uri
     CONTAINER_DEFAULT_CPU                  = var.container_default_cpu
     CONTAINER_DEFAULT_MEMORY               = var.container_default_memory
     AAD_TENANT_ID                          = var.tenant_id

--- a/terraform/keyvault.tf
+++ b/terraform/keyvault.tf
@@ -1,0 +1,24 @@
+# ── Key Vault ─────────────────────────────────────────────────────────────────
+#
+# Stores arbitrary secrets managed through the backend's GetSecret/SetSecret
+# admin functions. Access is granted via Azure RBAC only — the backend Function's
+# managed identity is the sole principal allowed to read and write secrets
+# (people with portal access can be granted roles separately in Azure).
+
+resource "azurerm_key_vault" "this" {
+  name                      = "${local.product_prefix}-${var.fkhDeploymentName}-keyvault"
+  resource_group_name       = azurerm_resource_group.this.name
+  location                  = azurerm_resource_group.this.location
+  tenant_id                 = var.tenant_id
+  sku_name                   = lower(var.keyvault_sku)
+  rbac_authorization_enabled = true
+
+  tags = azurerm_resource_group.this.tags
+}
+
+# Grant the Function's identity read + write access to secrets in the Key Vault.
+resource "azurerm_role_assignment" "function_keyvault_secrets" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = azurerm_user_assigned_identity.function.principal_id
+}

--- a/terraform/keyvault.tf
+++ b/terraform/keyvault.tf
@@ -6,7 +6,7 @@
 # (people with portal access can be granted roles separately in Azure).
 
 resource "azurerm_key_vault" "this" {
-  name                      = "${local.product_prefix}-${lower(local.storage_account_org_id)}-kv"
+  name                      = "${local.product_prefix}${lower(local.storage_account_org_id)}kv"
   resource_group_name       = azurerm_resource_group.this.name
   location                  = azurerm_resource_group.this.location
   tenant_id                 = var.tenant_id

--- a/terraform/keyvault.tf
+++ b/terraform/keyvault.tf
@@ -6,7 +6,7 @@
 # (people with portal access can be granted roles separately in Azure).
 
 resource "azurerm_key_vault" "this" {
-  name                      = "${local.product_prefix}-${var.fkhDeploymentName}-keyvault"
+  name                      = "${local.product_prefix}-${lower(local.storage_account_org_id)}-kv"
   resource_group_name       = azurerm_resource_group.this.name
   location                  = azurerm_resource_group.this.location
   tenant_id                 = var.tenant_id

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -78,6 +78,16 @@ output "acr_name" {
   value       = azurerm_container_registry.this.name
 }
 
+output "keyvault_name" {
+  description = "Name of the Key Vault."
+  value       = azurerm_key_vault.this.name
+}
+
+output "keyvault_uri" {
+  description = "URI of the Key Vault."
+  value       = azurerm_key_vault.this.vault_uri
+}
+
 output "dbs_storage_account_name" {
   description = "Name of the storage account for database backups."
   value       = azurerm_storage_account.dbs.name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,6 +69,17 @@ variable "acr_sku" {
   }
 }
 
+variable "keyvault_sku" {
+  description = "Key Vault pricing tier. 'Standard' for software-protected keys, 'Premium' for HSM-backed keys."
+  type        = string
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Standard", "Premium"], var.keyvault_sku)
+    error_message = "keyvault_sku must be one of: Standard, Premium."
+  }
+}
+
 variable "windows_min_node_count" {
   description = "Minimum number of Windows nodes to keep running (0 = scale to zero, 1 = always keep a warm node)."
   type        = number


### PR DESCRIPTION
This pull request introduces robust support for managing and securely accessing secrets via Azure Key Vault in the backend API. It adds three new API endpoints for getting, setting, and listing secrets, and implements automatic substitution of secret references in function parameters. Additionally, it improves authentication tracking by introducing an `IsOidc` flag. These changes enhance security, flexibility, and usability for both personal and organization-wide secrets.

**Key Vault Integration and Secret Management:**

* Added three new API endpoints: `GetSecret`, `SetSecret`, and `ListSecrets`, allowing users to retrieve, create/update/remove, and list secrets in the deployment's Key Vault, with support for personal and organization-wide secrets. (`fkh-backend/FunctionCatalog.cs` [[1]](diffhunk://#diff-133b3defff5b66955ec9b12d74ee56829b30e45d385c2ab8a139a3d2cecd9145R1361-R1417) `fkh-backend/GetSecretFunction.cs` [[2]](diffhunk://#diff-ae3d5043a62751a209930686b74b2678bfbea12104333e20659f4b299007b919R1-R25) `fkh-backend/ListSecretsFunction.cs` [[3]](diffhunk://#diff-f3882d9b564664913ff387cf213ae3651f30b8afe35d6ff4fdbe8d320ed16e59R1-R25)
* Registered the `FkhKeyVault` service for dependency injection to support Key Vault operations. (`fkh-backend/Program.cs` [fkh-backend/Program.csR64](diffhunk://#diff-ba334a174cedbcfca050819dddc2bd9cbee0e71c14fb759df208faf2e2d5303dR64))
* Added `keyvault_sku` configuration option to specify the Key Vault SKU in deployment settings. (`deployment-repo/config/deployment.tfvars` [deployment-repo/config/deployment.tfvarsR53](diffhunk://#diff-47a88f35ee54177c8d0194af4fe74a1a4d1bacad22dd4ca91fe313c74eb48918R53))

**Automatic Secret Reference Substitution:**

* Implemented logic to automatically substitute parameter values of the form `@secretName@` with the corresponding Key Vault secret value before executing operations, with fallback from personal to organization secrets and error handling for missing secrets. (`fkh-backend/FunctionBase.cs` [[1]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR285-R296) [[2]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR470-R479) [[3]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR512-R520) [[4]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR859-R919)

**Authentication Enhancements:**

* Added an `IsOidc` flag to the authentication result to track if a request was authenticated via OIDC, and included this flag in parameter propagation and secret resolution logic. (`fkh-backend/FunctionBase.cs` [[1]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR592) [[2]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR654) [[3]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR669) [[4]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR685) [[5]](diffhunk://#diff-d4312d8f6a82fb460a816c6a842a54f51650660b3f66fff06f968c16ce7334dfR724)

These changes significantly improve the security and manageability of secrets in the backend, and lay the groundwork for secure, user-scoped, and organization-scoped secret handling across the API.